### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 *.pyc
 *~
+.project
+.pydevproject
 release-tmp/
 .idea
+

--- a/dali/test_command.py
+++ b/dali/test_command.py
@@ -1,4 +1,20 @@
-from . import command, address, commands
+try:
+
+    from dali import command, address, commands
+
+except:
+    # Realign paths, and try import again
+    # Since pyCharm's unittest runner fails on relative imports
+
+    import sys
+    import os
+
+    PACKAGE_PARENT = '..'
+    SCRIPT_DIR = os.path.dirname(os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
+    sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))
+
+    from dali import command, address, commands
+
 import unittest
 
 # Only test device types up to this number - if we went all the way to

--- a/tcp-listen.py
+++ b/tcp-listen.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+__author__ = 'psari'
+
+import socket
+
+TCP_IP = '127.0.0.1'
+TCP_PORT = 55825
+BUFFER_SIZE = 20  # Normally 1024, but we want fast response
+
+while True:
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind((TCP_IP, TCP_PORT))
+    s.listen(1)
+
+    conn, addr = s.accept()
+
+    try:
+        print("Connection address:", addr)
+        while 1:
+            conn.setblocking(0)
+            conn.settimeout(20.0)
+            data = conn.recv(BUFFER_SIZE)
+            if not data:
+                break
+
+            stream = ":".join("{:02x}".format(ord(chr(c))) for c in data)
+            print("received data: [{1}] {0}".format(stream, len(data)))
+
+            # conn.send(data)  # echo
+            conn.send(b"\x02\xff\x00\x00")
+    except:
+        pass
+
+    conn.close()


### PR DESCRIPTION
I have a few things to review 
- I had to put a `pythonpath` realigment to the unittests, to make it run with Pycharm's unittest runner. It works with `python -m unittest discover` too. 
- I've put a dummy TCP listener for debugging purposes, nothing special
- I've added gitignore rules to ignore Eclipse's project files too.