### PR TITLE
Use Python 3 compatible decorator for setting metaclasses

### DIFF
--- a/dali/address.py
+++ b/dali/address.py
@@ -15,6 +15,7 @@ Addressing for event messages is described in IEC 62386-103 section
 """
 
 from __future__ import unicode_literals
+from dali.compat import add_metaclass
 
 class IncompatibleFrame(Exception):
     """Cannot set destination address in supplied frame"""
@@ -32,9 +33,9 @@ class AddressTracker(type):
             cls._addrtypes.append(cls)
 
 
+@add_metaclass(AddressTracker)
 class Address(object):
     """An address for one or more ballasts."""
-    __metaclass__ = AddressTracker
 
     @classmethod
     def from_frame(cls, f):

--- a/dali/command.py
+++ b/dali/command.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 from dali import address
 from dali import frame
+from dali.compat import add_metaclass
 
 class CommandTracker(type):
     """Metaclass keeping track of all the types of Command we understand."""
@@ -79,12 +80,12 @@ class BitmapResponseBitDict(type):
                 bit = bit + 1
             cls._bit_properties = bd
 
+@add_metaclass(BitmapResponseBitDict)
 class BitmapResponse(Response):
     """A response that consists of several named bits.
 
     Bits are listed in subclasses with the least-sigificant bit first.
     """
-    __metaclass__ = BitmapResponseBitDict
     _expected = True
     bits = []
     @property
@@ -119,6 +120,7 @@ class BitmapResponse(Response):
         except Exception as e:
             return unicode(e)
 
+@add_metaclass(CommandTracker)
 class Command(object):
     """A command frame.
 
@@ -126,7 +128,6 @@ class Command(object):
     passed a Frame returns a new instance of the class corresponding
     to that command, or "None" if there is no match.
     """
-    __metaclass__ = CommandTracker
 
     # Override this as appropriate
     _framesize = 0

--- a/dali/compat.py
+++ b/dali/compat.py
@@ -1,0 +1,18 @@
+# Python compatibility support code
+# This is taken from six
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper


### PR DESCRIPTION
Referring to https://github.com/sde1000/python-dali/issues/3: @caiwan may you give py3 another try?

@sde1000 the compat code is actually taken from six, no need to depend to the whole library in this case IMHO.