### PR TITLE
UART/Serial communication

### DIFF
--- a/dali/address.py
+++ b/dali/address.py
@@ -171,8 +171,10 @@ class Short(Address):
     def __init__(self, address):
         if not isinstance(address, int):
             raise ValueError("address must be an integer")
+
         if address < 0 or address > 63:
             raise ValueError("address must be in the range 0..63")
+
         self.address = address
 
     @classmethod

--- a/dali/driver/daliserver.py
+++ b/dali/driver/daliserver.py
@@ -67,7 +67,7 @@ class DaliServer(DriverInterface):
             if not self._s:
                 s.close()
 
-        response = self.unpack_response(command, result)
+        response = self._unpack_response(command, result)
 
         if response:
             logging.info(u"  -> {0}".format(response))

--- a/dali/driver/daliserver.py
+++ b/dali/driver/daliserver.py
@@ -1,0 +1,77 @@
+"""
+Daliserver
+Communicates with daliserver through tcp
+"""
+
+__author__ = 'caiwan'
+
+from __future__ import print_function
+import socket
+import logging
+from dali.command import Command
+
+from dali.interface import DriverInterface
+
+
+class DaliServer(DriverInterface):
+    """
+    Communicate with daliserver
+    (https://github.com/onitake/daliserver)
+
+    NB this requires daliserver commit
+    90e34a0cd2945dc7a15681f11647e708f858521e or later.
+
+    """
+
+    def __init__(self, host="localhost", port=55825,
+                 multiple_frames_per_connection=False):
+        self._target = (host, port)
+        self._s = None
+        self._multiple_frames_per_connection = multiple_frames_per_connection
+
+    def __enter__(self):
+        if self._multiple_frames_per_connection:
+            self._s = socket.create_connection(self._target)
+        return self
+
+    def __exit__(self, *vpass):
+        # print(vpass)
+        if self._multiple_frames_per_connection:
+            self._s.close()
+            self._s = None
+
+    def send(self, command):
+        if self._s:
+            s = self._s
+        else:
+            s = socket.create_connection(self._target)
+
+        assert isinstance(command, Command)
+        message = command.pack
+
+        logging.info(u"command: {}{}".format(
+            command, " (twice)" if command._isconfig else ""))
+
+        # Set a default result which may be used if the first send fails
+        result = "\x02\xff\x00\x00"
+
+        try:
+            s.send(message)
+            result = s.recv(4)
+            if command._isconfig:
+                s.send(message)
+                result = s.recv(4)
+        except:
+            raise
+        finally:
+            if not self._s:
+                s.close()
+
+        response = self.unpack_response(command, result)
+
+        if response:
+            logging.info(u"  -> {0}".format(response))
+
+        return response
+
+

--- a/dali/driver/uart.py
+++ b/dali/driver/uart.py
@@ -1,0 +1,79 @@
+
+"""
+UART communication driver for DALI
+"""
+
+import logging
+import serial
+from dali.command import Command
+from dali.interface import DriverInterface, ParameterError
+
+
+class DaliUART(DriverInterface):
+    """
+    Uart driver for DALI
+    """
+    
+    def __init__(self, com, baud=115200):
+        """
+        :param:com port name
+        :param:baud baud rate - 11520 default
+        """
+        self._s = None
+        self._uart = (com, baud)
+
+    def __enter__(self):
+        """
+        Entry point of the context manager 
+        """
+        
+        self._s = serial.Serial(self._uart[0], self._uart[1], timeout=0.001)
+
+        return self
+        
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """
+        Teardown for context manager
+        """
+        
+        self._s.close()
+        
+    def send(self, command):
+        """
+        Send a DALI command, and recv. response if there's any expected
+        :param command: command object
+        :return: response object
+        """
+        assert isinstance(command, Command)
+        assert self._s is not None
+        assert isinstance(self._s, serial.Serial)
+
+        recv_data = None
+        response = None
+
+        try:
+            data = command.pack
+            logging.info("Send data: {0}".format(":".join("{:02x}".format(ord(c)) for c in data)))
+            self._s.write(data)
+
+            if command.is_query:
+                logging.info("Query, awaiting response")
+                self._s.timeout = 1
+                recv_data = self._s.read(4)
+
+            if recv_data is not None:
+                logging.info("Recv data: {0}".format(":".join("{:02x}".format(ord(c)) for c in recv_data)))
+                try:
+                    response = self._unpack_response(command, recv_data)
+                except:
+                    raise ParameterError
+
+                if response:
+                    logging.info(u"  -> {0}".format(response))
+
+        except:
+            # nothing to have here yet
+            raise
+        # no need to clean up connection here
+
+        return response

--- a/dali/driver/uart.py
+++ b/dali/driver/uart.py
@@ -5,6 +5,7 @@ UART communication driver for DALI
 
 import logging
 import serial
+import struct
 from dali.command import Command
 from dali.interface import DriverInterface, ParameterError
 
@@ -52,7 +53,13 @@ class DaliUART(DriverInterface):
         response = None
 
         try:
-            data = command.pack
+            #
+            crc = 0
+            for c in list(command.pack):
+                crc ^= ord(c)
+
+            # send data in reverse order
+            data = struct.pack("B", len(command)) + command.pack + struct.pack("B", crc)
             logging.info("Send data: {0}".format(":".join("{:02x}".format(ord(c)) for c in data)))
             self._s.write(data)
 

--- a/dali/interface.py
+++ b/dali/interface.py
@@ -7,6 +7,9 @@ class CommunicationError(Exception):
     pass
 
 
+class ParameterError(Exception):
+    pass
+
 class DriverInterface(object):
     """
     Driver interface class
@@ -32,6 +35,8 @@ class DriverInterface(object):
         """
 
         assert isinstance(command, Command)
+        assert isinstance(result, str)
+        assert len(result) is 4
 
         ver, status, rval, pad = struct.unpack("BBBB", result)
         response = None

--- a/dali/interface.py
+++ b/dali/interface.py
@@ -1,7 +1,5 @@
 from __future__ import print_function
 from dali.command import Command
-import logging
-import socket
 import struct
 
 
@@ -9,68 +7,24 @@ class CommunicationError(Exception):
     pass
 
 
-class DaliServer(object):
-    """Communicate with daliserver
-    (https://github.com/onitake/daliserver)
-
-    NB this requires daliserver commit
-    90e34a0cd2945dc7a15681f11647e708f858521e or later.
+class DriverInterface(object):
+    """
+    Driver interface class
+    Contains the common definition of functions for variousdrivers
     """
 
-    def __init__(self, host="localhost", port=55825,
-                 multiple_frames_per_connection=False):
-        self._target = (host, port)
-        self._s = None
-        self._multiple_frames_per_connection = multiple_frames_per_connection
+    def send(self):
+        """
+        Send command, and returns its response
+        :return:
+        """
+        raise RuntimeError("Not implemented method")
 
-    def __enter__(self):
-        if self._multiple_frames_per_connection:
-            self._s = socket.create_connection(self._target)
-        return self
-
-    def __exit__(self, *vpass):
-        print(vpass)
-        if self._multiple_frames_per_connection:
-            self._s.close()
-            self._s = None
-
-    def send(self, command):
-        if self._s:
-            s = self._s
-        else:
-            s = socket.create_connection(self._target)
-
-        assert isinstance(command, Command)
-        message = struct.pack("BB", 2, 0) + command.frame.pack
-
-        logging.info(u"command: {}{}".format(
-            command, " (twice)" if command.is_config else ""))
-
-        # Set a default result which may be used if the first send fails
-        result = "\x02\xff\x00\x00"
-
-        try:
-            s.send(message)
-            result = s.recv(4)
-            if command.is_config:
-                s.send(message)
-                result = s.recv(4)
-        except:
-            raise
-        finally:
-            if not self._s:
-                s.close()
-
-        response = self.unpack_response(command, result)
-
-        if response:
-            logging.info(u"  -> {0}".format(response))
-
-        return response
-
-    def unpack_response(self, command, result):
-        """Unpack result from the given bytestream and creates the
-        corresponding response object
+    @staticmethod
+    def _unpack_response(command, result):
+        """
+        Unpack result from the given bytestream and creates the corresponding
+        response object
 
         :param command: the command which waiting for it's response
         :param result: the result bytestream which came back

--- a/examples/dalitest.py
+++ b/examples/dalitest.py
@@ -7,21 +7,25 @@ from dali.gear.emergency import QueryEmergencyFailureStatus
 from dali.gear.emergency import QueryEmergencyFeatures
 from dali.gear.emergency import QueryEmergencyMode
 from dali.gear.emergency import QueryEmergencyStatus
-from dali.driver.daliserver import DaliServer
+#from dali.driver.daliserver import DaliServer
+from dali.driver.uart import DaliUART
 import logging
 
 if __name__ == "__main__":
     log_format = '%(levelname)s: %(message)s'
     logging.basicConfig(format=log_format, level=logging.DEBUG)
 
-    with DaliServer() as d:
+    #with DaliServer() as d:
+    d = DaliUART('COM3')
+
+    with d:
         for addr in range(0, 64):
             cmd = QueryDeviceType(Short(addr))
             r = d.send(cmd)
 
             logging.info("[%d]: resp: %s" % (addr, r))
 
-            if r.value == 1:
+            if r and r.value is 1:
                 d.send(EnableDeviceType(1))
                 r = d.send(QueryEmergencyMode(Short(addr)))
                 logging.info(" -- {0}".format(r))

--- a/examples/dalitest.py
+++ b/examples/dalitest.py
@@ -7,7 +7,7 @@ from dali.gear.emergency import QueryEmergencyFailureStatus
 from dali.gear.emergency import QueryEmergencyFeatures
 from dali.gear.emergency import QueryEmergencyMode
 from dali.gear.emergency import QueryEmergencyStatus
-from dali.interface import DaliServer
+from dali.driver.daliserver import DaliServer
 import logging
 
 if __name__ == "__main__":

--- a/examples/dalitest.py
+++ b/examples/dalitest.py
@@ -7,18 +7,31 @@ from dali.gear.emergency import QueryEmergencyFailureStatus
 from dali.gear.emergency import QueryEmergencyFeatures
 from dali.gear.emergency import QueryEmergencyMode
 from dali.gear.emergency import QueryEmergencyStatus
-#from dali.driver.daliserver import DaliServer
+from dali.driver.daliserver import DaliServer
 from dali.driver.uart import DaliUART
 import logging
+
+import time
 
 if __name__ == "__main__":
     log_format = '%(levelname)s: %(message)s'
     logging.basicConfig(format=log_format, level=logging.DEBUG)
 
-    #with DaliServer() as d:
-    d = DaliUART('COM3')
+    d = DaliServer()
+    #d = DaliUART('COM4')
 
     with d:
+
+        """
+        while True:
+            for i in range(0, 254, 10):
+                d.send(ArcPower(Broadcast(), i))
+                time.sleep(0.300)
+            for i in range(254, 0, 10):
+                d.send(ArcPower(Broadcast(), i))
+                time.sleep(0.300)
+        """
+
         for addr in range(0, 64):
             cmd = QueryDeviceType(Short(addr))
             r = d.send(cmd)
@@ -41,3 +54,4 @@ if __name__ == "__main__":
                 d.send(EnableDeviceType(1))
                 r = d.send(QueryEmergencyStatus(Short(addr)))
                 logging.info(" -- {0}".format(r))
+


### PR DESCRIPTION
- Common `DriverInterface` to create custom DALI drivers with it. 
- Communicates with a custom DALI controller through UART
- Binrary protocol, But can be extended with 7-bit ASCII
- Using frames, which starts with one byte length, and ends with one byte XOR CRC. 
- CRC check on the recieve side is missing yet. 