### PR TITLE
Missing attribute of Command._commands had fixed + unittest + cleanup

### DIFF
--- a/dali/command.py
+++ b/dali/command.py
@@ -15,11 +15,11 @@ class CommandTracker(type):
     """
 
     def __init__(cls, name, bases, attrs):
-        if not hasattr(cls, '_commands'):
-            cls._commands = []
+        if not hasattr(cls.__class__, '_commands'):
+            cls.__class__._commands = []
         else:
             if cls.__name__[0] != '_':
-                cls._commands.append(cls)
+                cls.__class__._commands.append(cls)
 
     @classmethod
     def commands(cls):

--- a/dali/frame.py
+++ b/dali/frame.py
@@ -156,6 +156,9 @@ class Frame(object):
         except:
             raise TypeError("Frame can only be added to another Frame")
 
+    def __hash__(self):
+        return hash(self._bits)
+
     @property
     def as_integer(self):
         """The contents of the frame represented as an integer."""

--- a/dali/test_command.py
+++ b/dali/test_command.py
@@ -1,32 +1,28 @@
-try:
-    from dali import address
-    from dali import command
-    from dali import frame
-    from dali.gear import general as generalgear
-    from dali.gear import emergency
-    from dali.gear import incandescent
-    from dali.gear import led
-    from dali.device import general as generaldevice
-except ImportError:
-    # Realign paths, and try import again
-    # Since pyCharm's unittest runner fails on relative imports
-    import os
-    import sys
+"""
+Unittest for commands
+"""
 
-    PACKAGE_PARENT = '..'
-    SCRIPT_DIR = os.path.dirname(
-        os.path.realpath(os.path.join(os.getcwd(),
-                         os.path.expanduser(__file__))))
-    sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))
+# Realign paths, and try import again
+# Since pyCharm's unittest runner fails on relative imports
+import os
+import sys
 
-    from dali import address
-    from dali import command
-    from dali import frame
-    from dali.gear import general as generalgear
-    from dali.gear import emergency
-    from dali.gear import incandescent
-    from dali.gear import led
-    from dali.device import general as generaldevice
+PACKAGE_PARENT = '..'
+SCRIPT_DIR = os.path.dirname(
+    os.path.realpath(os.path.join(os.getcwd(),
+                                  os.path.expanduser(__file__))))
+sys.path.append(os.path.normpath(os.path.join(SCRIPT_DIR, PACKAGE_PARENT)))
+
+from dali import address
+from dali import command
+from dali import frame
+from dali.gear import general as generalgear
+from dali.gear import emergency
+from dali.gear import incandescent
+from dali.gear import led
+from dali.device import general as generaldevice
+from dali.command import Command, CommandTracker
+
 import unittest
 
 # Only test device types up to this number - if we went all the way to
@@ -111,6 +107,12 @@ class TestCommands(unittest.TestCase):
                                __unicode__(), unicode),
                     "cmd {} unicode(response(0xff)) didn't return unicode".\
                     format(unicode(f)))
+
+    def test_command_tracker(self):
+        "Test accessibility of commands through CommandTracker"
+        for cmd in CommandTracker.commands():
+            self.assertTrue(issubclass(cmd, Command))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As I've mentioned [here](https://github.com/sde1000/python-dali/issues/29):
 - attribute _commands in CommandTracker class belonged to the type instead of the metaclass
 - added a dummy unittest that proves it's working
 - import error exception had removed, adds root path instantly, w/o condition, to reduce redundancy of imports