### PR TITLE
Driver overhaul - Add a general contract for writing various drivers for communication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /.pydevproject
 /bin/
 /build/
-/dali.egg-info/
 /dist/
 /dali.egg-info/
 /include/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.pydevproject
 /bin/
 /build/
+/dali.egg-info/
 /include/
 /lib/
 /local/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,17 @@
+Changes
+=======
+
+0.2
+---
+
+- Introduce basic sync and async drivers.
+  [rnix]
+
+- Basic implementation of LUNATONE Dali USB driver.
+  [rnix]
+
+0.1
+---
+
+- Initial release.
+  [sde1000]

--- a/dali/driver/base.py
+++ b/dali/driver/base.py
@@ -1,0 +1,41 @@
+"""Basic DALI driver related objects.
+
+A DALI driver is any service or gateway which is able to communicate with a
+physical DALI bus.
+"""
+
+class DALIDriver(object):
+    """Object for handling data received from and sent to specific DALI
+    Gateways.
+
+    The API design is meant to fit synchronous and asynchronous implementations.
+    """
+
+    dispatcher = None
+    """Callable used for dispatching incoming forward frames."""
+
+    def receive(self, data):
+        """Extract and dispatch DALI Frame from received data.
+
+        If a forward frame is received, ``self.dispatcher`` is used for
+        delegating.
+
+        If a backward frame is received, the ``callback`` given in
+        ``self.send`` is used.
+
+        @param data: raw data received from gateway.
+        """
+        raise NotImplementedError(
+            'Abstract ``DALIDriver`` does not implement ``receive``')
+
+    def send(self, command, callback=None, **kw):
+        """Construct raw data containing the packed DALI frame from command and
+        send to gateway.
+
+        @param command: DALI command to send.
+        @param callback: Function which gets called with received response.
+        @param **kw: Optional keyword arguments which get passed to response
+                     callback
+        """
+        raise NotImplementedError(
+            'Abstract ``DALIDriver`` does not implement ``send``')

--- a/dali/driver/base.py
+++ b/dali/driver/base.py
@@ -7,7 +7,7 @@ import usb
 # driver contracts
 ###############################################################################
 
-class DaliDriver(object):
+class DALIDriver(object):
     """Object for handling wrapped DALI frames sent to and received from
     DALI drivers.
 
@@ -39,7 +39,7 @@ class DaliDriver(object):
             'Abstract ``DaliDriver`` does not implement ``extract``')
 
 
-class SyncDALIDriver(DaliDriver):
+class SyncDALIDriver(DALIDriver):
     """Object for synchronously sending data to DALI drivers immediately
     expecting and returning a result.
     """
@@ -55,7 +55,7 @@ class SyncDALIDriver(DaliDriver):
             'Abstract ``SyncDALIDriver`` does not implement ``send``')
 
 
-class AsyncDALIDriver(DaliDriver):
+class AsyncDALIDriver(DALIDriver):
     """Object for asynchronously handling data sent to and received from
     DALI drivers.
     """
@@ -221,7 +221,7 @@ class USBListener(USBBackend, Listener):
         """
         while not self._stop_listening.is_set():
             try:
-                self.driver.received(self.read())
+                self.driver.receive(self.read())
             except usb.core.USBError, e:
                 # read timeout
                 if e.errno == 110:

--- a/dali/driver/base.py
+++ b/dali/driver/base.py
@@ -198,7 +198,7 @@ class USBListener(USBBackend, Listener):
     """Listener implementation for communicating with USB devices.
     """
 
-    def __init__(self, vendor, product, bus=None,
+    def __init__(self, driver, vendor, product, bus=None,
                  port_numbers=None, interface=0):
         super(USBListener, self).__init__(
             vendor,
@@ -207,6 +207,7 @@ class USBListener(USBBackend, Listener):
             port_numbers=port_numbers,
             interface=interface
         )
+        self.driver = driver
         # flag whether actually disconnecting from device
         self._disconnecting = False
         # event to stop listening

--- a/dali/driver/base.py
+++ b/dali/driver/base.py
@@ -1,36 +1,82 @@
-"""Basic DALI driver related objects.
+from __future__ import unicode_literals
+import threading
+import usb
 
-A DALI driver is any service or gateway which is able to communicate with a
-physical DALI bus.
-"""
 
-class DALIDriver(object):
-    """Object for handling data received from and sent to specific DALI
-    Gateways.
+###############################################################################
+# driver contracts
+###############################################################################
 
-    The API design is meant to fit synchronous and asynchronous implementations.
+class DaliDriver(object):
+    """Object for handling wrapped DALI frames sent to and received from
+    DALI drivers.
+
+    A DALI driver represents a service or physical gateway which is able to
+    communicate with a DALI bus.
+    """
+
+    def extract(self, data):
+        """Extract and return DALI Frame from data which has been received
+        from DALI driver.
+
+        @param data: Raw data received from gateway.
+        @return frame: Returns ``dali.frame.Frame`` deriving object.
+        """
+        raise NotImplementedError(
+            'Abstract ``DaliDriver`` does not implement ``extract``')
+
+    def construct(self, command):
+        """Construct raw data containing the packed DALI frame from command
+        which can be sent to DALI driver.
+
+        @param command: DALI command to send.
+        @return data: Returns data which can be sent to backend.
+        """
+        raise NotImplementedError(
+            'Abstract ``DaliDriver`` does not implement ```construct`')
+
+
+class SyncDALIDriver(DaliDriver):
+    """Object for synchronously sending data to DALI drivers immediately
+    expecting and returning a result.
+    """
+
+    def send(self, command, timeout=None):
+        """Send command to gateway and return response.
+
+        @param command: DALI command to send.
+        @param timeout: Timeout in milliseconds.
+        @return response: response to command.
+        """
+        raise NotImplementedError(
+            'Abstract ``SyncDALIDriver`` does not implement ``send``')
+
+
+class AsyncDALIDriver(DaliDriver):
+    """Object for asynchronously handling data received from and sent to
+    DALI drivers.
     """
 
     dispatcher = None
-    """Callable used for dispatching incoming forward frames."""
+    """Callable used for dispatching incoming forward frames.
+    """
 
-    def receive(self, data):
-        """Extract and dispatch DALI Frame from received data.
+    def receive(self, frame):
+        """Receive DALI Frame.
 
         If a forward frame is received, ``self.dispatcher`` is used for
-        delegating.
+        delegating it.
 
         If a backward frame is received, the ``callback`` given in
         ``self.send`` is used.
 
-        @param data: raw data received from gateway.
+        @param frame: ``dali.frame.Frame`` deriving object.
         """
         raise NotImplementedError(
-            'Abstract ``DALIDriver`` does not implement ``receive``')
+            'Abstract ``AsyncDALIDriver`` does not implement ``receive``')
 
     def send(self, command, callback=None, **kw):
-        """Construct raw data containing the packed DALI frame from command and
-        send to gateway.
+        """Send command to gateway.
 
         @param command: DALI command to send.
         @param callback: Function which gets called with received response.
@@ -38,4 +84,150 @@ class DALIDriver(object):
                      callback
         """
         raise NotImplementedError(
-            'Abstract ``DALIDriver`` does not implement ``send``')
+            'Abstract ``AsyncDALIDriver`` does not implement ``send``')
+
+
+###############################################################################
+# backend contracts
+###############################################################################
+
+class Backend(object):
+    """Object representing a backend.
+    """
+
+    def read(self, timeout=None):
+        raise NotImplementedError(
+            'Abstract ``Backend`` does not implement ``read``')
+
+    def write(data):
+        raise NotImplementedError(
+            'Abstract ``Backend`` does not implement ``write``')
+
+    def close(self):
+        raise NotImplementedError(
+            'Abstract ``Backend`` does not implement ``close``')
+
+
+class Listener(Backend):
+    """Object representing a backend which is permanently listening for
+    incoming frames.
+    """
+
+    driver = None
+    """``AsyncDALIDriver`` instance.
+    """
+
+    def listen(self):
+        """Listen to backend and dispatch receiced data to ``self.driver``.
+        """
+        raise NotImplementedError(
+            'Abstract ``Listener`` does not implement ``listen``')
+
+
+###############################################################################
+# USB backends
+###############################################################################
+
+class USBBackend(Backend):
+    """Backend implementation for communicating with USB devices.
+    """
+
+    def __init__(self, vendor, product, bus=None,
+                 port_numbers=None, interface=0):
+        self._device = None
+        # lookup devices by vendor and product
+        devices = [dev for dev in usb.core.find(
+            find_all=True,
+            idVendor=vendor,
+            idProduct=product
+        )]
+        # use first device if bus or port_numers not defined
+        if bus is None or port_numbers is None:
+            self._device = devices[0]
+        else:
+            for dev in devices:
+                if dev.bus == bus and dev.port_numbers == port_numbers:
+                    self._device = dev
+                    break
+        # if queried device not found, raise
+        if not self._device:
+            raise usb.core.USBError('Device not found')
+        # detach kernel driver if necessary
+        if self._device.is_kernel_driver_active(interface) is True:
+            self._device.detach_kernel_driver(interface)
+        # set device configuration
+        self._device.set_configuration()
+        # claim interface
+        usb.util.claim_interface(self._device, interface)
+        # get active configuration
+        cfg = self._device.get_active_configuration()
+        intf = cfg[(0, 0)]
+        # get write end point
+        def match_ep_out(e):
+            return usb.util.endpoint_direction(e.bEndpointAddress) == \
+                   usb.util.ENDPOINT_OUT
+        self._ep_write = usb.util.find_descriptor(
+            intf, custom_match=match_ep_out)
+        # get read end point
+        def match_ep_in(e):
+            return usb.util.endpoint_direction(e.bEndpointAddress) == \
+                   usb.util.ENDPOINT_IN
+        self._ep_read = usb.util.find_descriptor(
+            intf, custom_match=match_ep_in)
+
+    def read(self, timeout=None):
+        """Read data from USB device.
+        """
+        return self._ep_read.read(self._ep_read.wMaxPacketSize, timeout=timeout)
+
+    def write(self, data):
+        """Write data to USB device.
+        """
+        return self._ep_write.write(data)
+
+    def close(self):
+        """Close connection to USB device.
+        """
+        usb.util.dispose_resources(self._device)
+
+
+class USBListener(USBBackend, Listener):
+    """Listener implementation for communicating with USB devices.
+    """
+
+    def __init__(self, vendor, product, bus=None,
+                 port_numbers=None, interface=0):
+        super(USBListener, self).__init__(
+            vendor,
+            product,
+            bus=bus,
+            port_numbers=port_numbers,
+            interface=interface
+        )
+        # flag whether actually disconnecting from device
+        self._disconnecting = False
+        # event for stop listening
+        self._stop_listening = threading.Event()
+        # create and start listener thread
+        self._listener = threading.Thread(target=self.listen)
+        self._listener.start()
+
+    def listen(self):
+        """Poll data from USB device.
+        """
+        while not self._stop_listening.is_set():
+            try:
+                self.driver.received(self.read())
+            except usb.core.USBError, e:
+                # read timeout
+                if e.errno == 110:
+                    continue
+                if not self._disconnecting:
+                    self.close()
+
+    def close(self):
+        """Close connection to USB device.
+        """
+        self._disconnecting = True
+        self._stop_listening.set()
+        super(USBListener, self).close()

--- a/dali/driver/base.py
+++ b/dali/driver/base.py
@@ -15,15 +15,8 @@ class DaliDriver(object):
     communicate with a DALI bus.
     """
 
-    def extract(self, data):
-        """Extract and return DALI Frame from data which has been received
-        from DALI driver.
-
-        @param data: Raw data received from gateway.
-        @return frame: Returns ``dali.frame.Frame`` deriving object.
-        """
-        raise NotImplementedError(
-            'Abstract ``DaliDriver`` does not implement ``extract``')
+    backend = None
+    """``Backend`` instance used for reading and writing."""
 
     def construct(self, command):
         """Construct raw data containing the packed DALI frame from command
@@ -34,6 +27,16 @@ class DaliDriver(object):
         """
         raise NotImplementedError(
             'Abstract ``DaliDriver`` does not implement ```construct`')
+
+    def extract(self, data):
+        """Extract and return DALI Frame from data which has been received
+        from DALI driver.
+
+        @param data: Raw data received from gateway.
+        @return frame: Returns ``dali.frame.Frame`` deriving object.
+        """
+        raise NotImplementedError(
+            'Abstract ``DaliDriver`` does not implement ``extract``')
 
 
 class SyncDALIDriver(DaliDriver):
@@ -53,13 +56,24 @@ class SyncDALIDriver(DaliDriver):
 
 
 class AsyncDALIDriver(DaliDriver):
-    """Object for asynchronously handling data received from and sent to
+    """Object for asynchronously handling data sent to and received from
     DALI drivers.
     """
 
     dispatcher = None
     """Callable used for dispatching incoming forward frames.
     """
+
+    def send(self, command, callback=None, **kw):
+        """Send command to gateway.
+
+        @param command: DALI command to send.
+        @param callback: Function which gets called with received response.
+        @param **kw: Optional keyword arguments which get passed to response
+                     callback
+        """
+        raise NotImplementedError(
+            'Abstract ``AsyncDALIDriver`` does not implement ``send``')
 
     def receive(self, frame):
         """Receive DALI Frame.
@@ -74,17 +88,6 @@ class AsyncDALIDriver(DaliDriver):
         """
         raise NotImplementedError(
             'Abstract ``AsyncDALIDriver`` does not implement ``receive``')
-
-    def send(self, command, callback=None, **kw):
-        """Send command to gateway.
-
-        @param command: DALI command to send.
-        @param callback: Function which gets called with received response.
-        @param **kw: Optional keyword arguments which get passed to response
-                     callback
-        """
-        raise NotImplementedError(
-            'Abstract ``AsyncDALIDriver`` does not implement ``send``')
 
 
 ###############################################################################
@@ -206,7 +209,7 @@ class USBListener(USBBackend, Listener):
         )
         # flag whether actually disconnecting from device
         self._disconnecting = False
-        # event for stop listening
+        # event to stop listening
         self._stop_listening = threading.Event()
         # create and start listener thread
         self._listener = threading.Thread(target=self.listen)

--- a/dali/driver/hasseb.py
+++ b/dali/driver/hasseb.py
@@ -5,6 +5,10 @@ import struct
 from time import sleep
 import logging
 
+
+# XXX: Adopt to new API
+
+
 class HassebUsb(object):
     """ Creates a server object which is able to communicate to the Hasseb DALI 
     Master device from http://hasseb.fi/ based on a NXP LPC1343 ARM microprocesor

--- a/dali/driver/tridonic.py
+++ b/dali/driver/tridonic.py
@@ -229,6 +229,7 @@ class AsyncTridonicDALIUSBDriver(TridonicDALIUSBDriver):
 
     def __init__(self, bus=None, port_numbers=None, interface=0):
         self.backend = USBListener(
+            self,
             DALI_USB_VENDOR,
             DALI_USB_PRODUCT,
             bus=bus,

--- a/dali/driver/tridonic.py
+++ b/dali/driver/tridonic.py
@@ -1,84 +1,202 @@
-# Experimental driver for Tridonic DALI-USB
-# NB requires pyusb-1.0; pyusb-0.4 is not suitable
-from __future__ import print_function
 from __future__ import unicode_literals
+from dali.driver.base import DALIDriver
+import logging
 import struct
-import usb.core
-import usb.util
 
 
-class DeviceNotFound(Exception):
-    pass
+logger = logging.getLogger('dali')
 
 
-class DaliUSB(object):
-    """A driver for a Tridonic/Lunatone DALI-USB interface."""
+DALI_USB_DIRECTION_DALI = 0x11,
+DALI_USB_DIRECTION_USB = 0x12,
+DALI_USB_TYPE_16BIT = 0x03,
+DALI_USB_TYPE_24BIT = 0x04,
+DALI_USB_TYPE_NO_RESPONSE = 0x71,
+DALI_USB_TYPE_RESPONSE = 0x72,
+DALI_USB_TYPE_COMPLETE = 0x73,
+DALI_USB_TYPE_BROADCAST = 0x74,
 
-    id_list = [(0x17b5, 0x0020)]
 
-    def __init__(self, address=None, serial=None):
-        """Find a DALI-USB device to drive.  The first device found is driven.
-        The arguments, if given, restrict the search:
+class TridonicDALIUSBDriver(DALIDriver):
+    """``DALIDriver`` implementation for Tridonic DALI USB device.
 
-        address is a (bus,device) tuple.
-        serial is a serial number string
+    This code borrows research and implementation details from ``daliserver``
+    (https://github.com/onitake/daliserver). Thanks to Gregor Riepl.
+    """
+    # debug logging
+    debug = True
+    # transaction mapping
+    _transactions = dict()
+    # next sequence number
+    _next_sn = 0
+
+    def receive(self, data):
+        """Data received from DALI USB:
+
+        dr ty ?? ec ad cm st st sn .. .. .. .. .. .. ..
+        11 73 00 00 ff 93 ff ff 00 00 00 00 00 00 00 00
+
+        dr: direction
+            0x11 = DALI side
+            0x12 = USB side
+        ty: type
+            0x71 = transfer no response
+            0x72 = transfer response
+            0x73 = transfer complete
+            0x74 = broadcast received (?)
+            0x77 = ?
+        ec: ecommand
+        ad: address
+        cm: command
+            also serves as response code for 72
+        st: status
+            internal status code, value unknown
+        sn: seqnum
         """
-        kwargs = {}
-        if address:
-            kwargs['bus'] = address[0]
-            kwargs['address'] = address[1]
-        if serial:
-            kwargs['serial_number'] = serial
+        dr = data[0]
+        ty = data[1]
+        ec = data[3]
+        ad = data[4]
+        cm = data[5]
+        st = struct.unpack('h', data[6:8])
+        sn = data[8]
+        # DALI -> DALI
+        if dr == DALI_USB_DIRECTION_DALI:
+            if ty == DALI_USB_TYPE_COMPLETE:
+                if self.debug:
+                    logger.info('DALI -> DALI (TYPE_COMPLETE)')
+                # DaliFramePtr frame = daliframe_new(in.address, in.command);
+                # dali->bcast_callback(USBDALI_SUCCESS, frame, in.status, dali->bcast_arg);
+                # XXX: how to construct?
+                frame = ForwardFrame() # ?
+                self._handle_dispatch(frame)
+                return
+            elif ty == DALI_USB_TYPE_BROADCAST:
+                if self.debug:
+                    logger.info('DALI -> DALI (TYPE_BROADCAST)')
+                # DaliFramePtr frame = daliframe_enew(in.ecommand, in.address, in.command);
+                # dali->bcast_callback(USBDALI_SUCCESS, frame, in.status, dali->bcast_arg);
+                # XXX: how to construct?
+                frame = ForwardFrame() # ?
+                self._handle_dispatch(frame)
+                return
+            else:
+                msg = 'Unknown type received: {}'.format(hex(ty))
+                raise ValueError(msg)
+        # USB -> DALI
+        elif dr == DALI_USB_DIRECTION_USB:
+            if ty == DALI_USB_TYPE_NO_RESPONSE:
+                if self.debug:
+                    logger.info('USB -> DALI (TYPE_NO_RESPONSE)')
+                # DaliFramePtr frame = daliframe_new(in.address, in.command);
+                # dali->req_callback(USBDALI_SUCCESS, frame, 0xff, in.status, dali->transaction->arg);
+                # XXX: what's the difference between NO_RESPONSE and RESPONSE?
+                #      same handling as RESPONSE? -> In daliserver actually
+                #      it looks like this is the BackwardFrameError case, right?
+                # XXX: how to construct?
+                frame = BackwardFrameError() # ?
+                self._handle_response(sn, frame)
+                return
+            elif ty == DALI_USB_TYPE_RESPONSE:
+                if self.debug:
+                    logger.info('USB -> DALI (TYPE_RESPONSE)')
+                # DaliFramePtr frame = daliframe_new(in.address, in.command);
+                # dali->req_callback(USBDALI_RESPONSE, frame, in.command, in.status, dali->transaction->arg);
+                # XXX: how to construct?
+                frame = BackwardFrame() # ?
+                self._handle_response(sn, frame)
+                return
+            elif ty == DALI_USB_TYPE_COMPLETE:
+                if self.debug:
+                    logger.info('USB -> DALI (TYPE_COMPLETE)')
+                # XXX: When does this happen? What should happen here?
+                return
+            else:
+                msg = 'Unknown type received: {}'.format(hex(ty))
+                raise ValueError(msg)
+        # Unknown direction
+        msg = 'Unknown direction received: {}'.format(hex(dr))
+        raise ValueError(msg)
 
-        def custom_match(x):
-            return (x.idVendor, x.idProduct) in DaliUSB.id_list
+    def send(self, command, callback=None, **kw):
+        """Data expected by DALI USB:
 
-        dev = usb.core.find(custom_match=custom_match, **kwargs)
-        if not dev:
-            raise DeviceNotFound
-        self._dev = dev
-        self._seqnum = 1
-        if self._dev.is_kernel_driver_active(0):
-            self._dev.detach_kernel_driver(0)
+        dr sn ?? ty ?? ec ad cm .. .. .. .. .. .. .. ..
+        12 1d 00 03 00 00 ff 08 00 00 00 00 00 00 00 00
 
-    @property
-    def serial_number(self):
-        return self._dev.serial_number
+        dr: direction
+            0x12 = USB side
+        sn: seqnum
+        ty: type
+            0x03 = 16bit
+            0x04 = 24bit
+        ec: ecommand
+        ad: address
+        cm: command
+        """
+        dr = 0x12
+        sn = self._get_sn()
+        frame = command.frame
+        ty = data = None
+        ec = 0x0
+        if len(frame) == 16:
+            ty = 0x03
+            ad, cm = frame.as_byte_sequence
+            data = struct.pack(
+                "BBBBBBBB" + (64 - 8) * 'x',
+                dr, sn, 0x0, ty, 0x0, ec, ad, cm
+            )
+        elif len(frame) == 24:
+            ty = 0x04
+            # XXX: not yet
+            raise ValueError('24 Bit frames not yet')
+        else:
+            raise ValueError('Unknown frame length: {}'.format(len(frame)))
+        self._transactions[sn] = {
+            'command': command,
+            'callback': callback,
+            'kw': kw
+        }
+        self.write(data)
 
-    def start(self):
-        """Detach the kernel driver and configure the device."""
-        self._dev.set_configuration()
-        self._dev.set_interface_altsetting(0)
+    def write(self):
+        """Write data to Gateway."""
+        raise NotImplementedError(
+            'Abstract ``TridonicDALIUSBDriver`` does not implement ``write``')
 
-    def send(self, command):
-        # Packets sent to the device appear to have the following format,
-        # in bytes (8 bytes total):
-        # 0x12   (direction - USB -> DALI)
-        # seqnum
-        # 0x00
-        # type  (0x03 = 16bit, 0x04 = 24bit)
-        # 0x00
-        # ecommand (unused in 16bit mode)
-        # a
-        # b
-        direction = 0x12
-        seqnum = self._seqnum
-        self._seqnum = self._seqnum+1
-        mtype = 0x03
-        ecommand = 0
-        a, b = command.frame.as_byte_sequence
-        msg = struct.pack(
-            "BBBBBBBB" + (64-8) * 'x',
-            direction, seqnum, 0, mtype, 0, ecommand, a, b
-        )
-        print(repr(msg))
-        l = self._dev.write(0x02, msg, 1000)
-        ret = self._dev.read(0x81, 64, 1000)
-        print(ret)
-        ret = self._dev.read(0x81, 64, 1000)
-        print(ret)
-        ret = self._dev.read(0x81, 64, 1000)
-        print(ret)
+    def _handle_dispatch(self, frame):
+        command = from_frame(frame)
+        if self.debug:
+            logger.info(str(command))
+        if self.dispatcher is None:
+            msg = 'Ignore received command: {}'.format(command)
+            logger.warning(msg)
+        else:
+            self.dispatcher(command)
 
-    def stop(self):
-        pass
+    def _handle_response(self, sn, frame):
+        request = self._transactions.get(sn)
+        if not request:
+            msg = 'Received response to unknown request: {}'.format(sn)
+            logger.error(msg)
+            return
+        del self._transactions[sn]
+        callback = request['callback']
+        if not callback:
+            if self.debug:
+                logger.info('No callback given for received response')
+            return
+        command = request['command']
+        if command.response:
+            callback(command._response(frame), **request['kw'])
+        else:
+            callback(frame, **request['kw'])
+
+    def _get_sn(self):
+        """Get next sequence number."""
+        sn = self._next_sn
+        if sn > 255:
+            self._next_sn = 0
+        else:
+            self._next_sn += 1
+        return sn

--- a/dali/driver/tridonic.py
+++ b/dali/driver/tridonic.py
@@ -196,7 +196,7 @@ class TridonicDALIUSBDriver(DALIDriver):
         """Get next sequence number."""
         sn = self._next_sn
         if sn > 255:
-            self._next_sn = 0
+            sn = self._next_sn = 0
         else:
             self._next_sn += 1
         return sn

--- a/dali/interface.py
+++ b/dali/interface.py
@@ -29,7 +29,6 @@ class DaliServer(object):
         return self
 
     def __exit__(self, *vpass):
-        print(vpass)
         if self._multiple_frames_per_connection:
             self._s.close()
             self._s = None

--- a/dali/interface.py
+++ b/dali/interface.py
@@ -6,6 +6,9 @@ import socket
 import struct
 
 
+# XXX: This should got into ``dali.driver.daliserver``
+
+
 class CommunicationError(Exception):
     pass
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+python-dali (0.2) unstable; urgency=low
+
+  * Introduce basic sync and async drivers.
+  * Basic implementation of LUNATONE Dali USB driver.
+
+ -- Robert Niederreiter <rnix@squarewave.at>  Mon, 20 Jun 2016 10:57:00 +0100
+
 python-dali (0.1) unstable; urgency=low
 
   * Initial release.
 
  -- Stephen Early <steve@greenend.org.uk>  Mon, 27 Apr 2015 18:05:00 +0100
-

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 
 setup(
     name='dali',
-    version='0.1',
+    version='0.2',
     description='Interface to DALI lighting systems',
     author='Stephen Early',
     author_email='steve@greenend.org.uk',


### PR DESCRIPTION
Implements #23.

This PR adds ``dali.driver.base``, which contains general contracts how to implement synchronous and asynchronous DALI drivers and USB backend implementation.

Further it adds a concrete driver implementation for Tridonic DALI USB device. It basically works, but needs more testing and finalization.
