### PR TITLE
Fix unpacking seqnum in tridonic async send

### DIFF
--- a/dali/driver/tridonic.py
+++ b/dali/driver/tridonic.py
@@ -255,7 +255,7 @@ class AsyncTridonicDALIUSBDriver(TridonicDALIUSBDriver, AsyncDALIDriver):
 
     def send(self, command, callback=None, **kw):
         data = self.construct(command)
-        sn = struct.unpack('B', data[1])[0]
+        sn = struct.unpack_from('B', data, 1)[0]
         self._transactions[sn] = {
             'command': command,
             'callback': callback,


### PR DESCRIPTION
Using subscript notation on struct seems to return the byte value as
an int on python 3, causing struct.unpack to raise. Switching
to unpack_from should preserve backwards compatibility.

Closes #49