### PR TITLE
Cleaning Hasseb driver

### DIFF
--- a/dali/driver/hasseb.py
+++ b/dali/driver/hasseb.py
@@ -7,12 +7,6 @@ from dali.driver.base import DALIDriver
 from dali.driver.base import SyncDALIDriver
 from dali.frame import BackwardFrame
 from dali.frame import BackwardFrameError
-from dali.exceptions import BadDevice
-from dali.exceptions import DeviceAlreadyBound
-from dali.exceptions import DuplicateDevice
-from dali.exceptions import NoFreeAddress
-from dali.exceptions import NotConnected
-from dali.exceptions import ProgramShortAddressFailure
 
 import dali.gear.general as gear
 


### PR DESCRIPTION
Finally got sometime to upgrade my setup with Hasseb controller.

The driver has these orphan imports

Also of note:
- It requires pyhidapi

From a previous PR from @hasseb :

"To install pyhidapi:  
git clone https://github.com/awelkie/pyhidapi.git  
cd pyhidapi  
sudo python3 setup.py install"

This is important as this library is not available as a pip package... can we replace this by something more standard @hasseb ?