### PR TITLE
Udev rules

### DIFF
--- a/examples/50-dali-hid.rules
+++ b/examples/50-dali-hid.rules
@@ -4,12 +4,9 @@
 # "dialout", and create symlinks in /dev/dali to the appropriate
 # hidraw devices.
 
-ACTION!="add", GOTO="dali_end"
-
 # Lunatone / Tridonic DALI USB
 SUBSYSTEMS=="usb", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="17b5", ATTRS{idProduct}=="0020", MODE="660", GROUP="dialout", SYMLINK="dali/daliusb-%s{serial}"
 
 # hasseb DALI Master, based on NXP LPC134x reference design
 SUBSYSTEMS=="usb", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04cc", ATTRS{idProduct}=="0802", MODE="660", GROUP="dialout", SYMLINK="dali/hasseb-%n"
 
-LABEL="dali_end"

--- a/examples/50-dali-hid.rules
+++ b/examples/50-dali-hid.rules
@@ -5,8 +5,8 @@
 # hidraw devices.
 
 # Lunatone / Tridonic DALI USB
-SUBSYSTEMS=="usb", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="17b5", ATTRS{idProduct}=="0020", MODE="660", GROUP="dialout", SYMLINK="dali/daliusb-%s{serial}"
+SUBSYSTEMS=="usb", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="17b5", ATTRS{idProduct}=="0020", MODE="660", GROUP="dialout", SYMLINK+="dali/daliusb-%s{serial}"
 
 # hasseb DALI Master, based on NXP LPC134x reference design
-SUBSYSTEMS=="usb", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04cc", ATTRS{idProduct}=="0802", MODE="660", GROUP="dialout", SYMLINK="dali/hasseb-%n"
+SUBSYSTEMS=="usb", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="04cc", ATTRS{idProduct}=="0802", MODE="660", GROUP="dialout", SYMLINK+="dali/hasseb-%n"
 


### PR DESCRIPTION
Enhances the _udev_ rules:

* In addition to physical connection, allows support of logical _udev_ triggering using `udevadm` command,
* Does not remove any previously created symbolic link for the device anymore.