### PR TITLE
Fix two small bugs in the asyncio Tridonic driver.

### DIFF
--- a/dali/driver/hid.py
+++ b/dali/driver/hid.py
@@ -412,7 +412,10 @@ class tridonic(hid):
             if len(self._bus_watch_data) == 0:
                 if current_command:
                     self._log.debug("Bus watch waiting with timeout")
-                    await asyncio.wait_for(self._bus_watch_data_available.wait(), 0.2)
+                    try:
+                        await asyncio.wait_for(self._bus_watch_data_available.wait(), 0.2)
+                    except asyncio.TimeoutError:
+                        pass
                 else:
                     self._log.debug("Bus watch waiting for data, no timeout")
                     await self._bus_watch_data_available.wait()

--- a/dali/driver/hid.py
+++ b/dali/driver/hid.py
@@ -570,7 +570,7 @@ class tridonic(hid):
         for event, messages in self._outstanding.values():
             messages.append("fail")
             event.set()
-        self._outstanding_values = {}
+        self._outstanding = {}
         # Cancel the bus watch task
         if self._bus_watch_task is not None:
             self._bus_watch_task.cancel()


### PR DESCRIPTION
This fixes two bugs that I spotted while working with the Tridonic driver:

- ```asyncio.wait_for()``` was called in ```tridonic._bus_watch()``` without handling the ```TimeoutError```
- ```tridonic._outstanding``` dictionary was not being reset correctly in ```tridonic._shutdown_device()```