### PR TITLE
Add sequence runner to Hasseb master

### DIFF
--- a/dali/driver/hasseb.py
+++ b/dali/driver/hasseb.py
@@ -88,11 +88,17 @@ class HassebDALIUSBDriver(DALIDriver):
             self.device_found = None
 
     def run_sequence(self, seq):
+        from dali.gear.general import EnableDeviceType
+
         response = None
         try:
             while True:
                 try:
+                    if cmd.devicetype != 0:
+                        self.send(EnableDeviceType(cmd.devicetype))
+
                     cmd = seq.send(response)
+
                 except StopIteration as r:
                     return r.value
                 if isinstance(cmd, sequence_sleep):

--- a/dali/driver/hasseb.py
+++ b/dali/driver/hasseb.py
@@ -94,9 +94,6 @@ class HassebDALIUSBDriver(DALIDriver):
         try:
             while True:
                 try:
-                    if cmd.devicetype != 0:
-                        self.send(EnableDeviceType(cmd.devicetype))
-
                     cmd = seq.send(response)
 
                 except StopIteration as r:
@@ -106,8 +103,9 @@ class HassebDALIUSBDriver(DALIDriver):
                 elif isinstance(cmd, sequence_progress):
                     print(cmd) # or call something else to deal with it
                 else:
-                    # XXX may need to send EnableDeviceType here for some commands
-                    # depending on whether or not the driver does it automatically
+                    if cmd.devicetype != 0:
+                        self.send(EnableDeviceType(cmd.devicetype))
+
                     response = self.send(cmd)
         finally:
             seq.close()

--- a/dali/driver/hasseb.py
+++ b/dali/driver/hasseb.py
@@ -87,7 +87,7 @@ class HassebDALIUSBDriver(DALIDriver):
         except:
             self.device_found = None
 
-    def run_sequence(self, seq):
+    def run_sequence(self, seq, progress_cb=None):
         from dali.gear.general import EnableDeviceType
 
         response = None
@@ -101,7 +101,10 @@ class HassebDALIUSBDriver(DALIDriver):
                 if isinstance(cmd, sequence_sleep):
                     time.sleep(cmd.delay)
                 elif isinstance(cmd, sequence_progress):
-                    print(cmd) # or call something else to deal with it
+                    if (callable(progress_cb)):
+                        progress_cb(sequence_progress)
+                    else:
+                        print(cmd)
                 else:
                     if cmd.devicetype != 0:
                         self.send(EnableDeviceType(cmd.devicetype))

--- a/dali/driver/hasseb.py
+++ b/dali/driver/hasseb.py
@@ -102,9 +102,7 @@ class HassebDALIUSBDriver(DALIDriver):
                     time.sleep(cmd.delay)
                 elif isinstance(cmd, sequence_progress):
                     if (callable(progress_cb)):
-                        progress_cb(sequence_progress)
-                    else:
-                        print(cmd)
+                        progress_cb(cmd)
                 else:
                     if cmd.devicetype != 0:
                         self.send(EnableDeviceType(cmd.devicetype))


### PR DESCRIPTION
Added a sequence runner to the Hasseb master. Implementation proposed by @sde1000 in https://github.com/sde1000/python-dali/issues/88, tested with sequences `Commissioning`, `QueryDeviceTypes`, `SetGroups`, and `QueryGroups`. 