### PR TITLE
Run driver tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,3 +29,7 @@ jobs:
       - name: Test with pytest
         run: |
           pytest dali/tests
+      - name: Run driver tests
+        run: |
+          pip install pymodbus pyusb
+          pytest dali/driver/tests


### PR DESCRIPTION
Was just checking changes to my fork and the upstream one and noticed that the CI setup changed.

Would it be OK to also run the driver tests I did create at the time?