### PR TITLE
Add support for DALI 24-bit event messages

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,6 +21,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Install dependencies (Python 3.6)
+        if: ${{ matrix.python-version == '3.6' }}
+        run: |
+          pip install dataclasses
       - name: Lint with flake8
         run: |
           flake8 dali --exclude=driver --count --ignore=E741,F403,F405,W503 --show-source --statistics --max-line-length=127

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
-          flake8 dali --exclude=driver --count --ignore=E741,F403,F405 --show-source --statistics --max-line-length=127
+          flake8 dali --exclude=driver --count --ignore=E741,F403,F405,W503 --show-source --statistics --max-line-length=127
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           #flake8 dali --exclude=driver --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ This library has been written with reference to the following documents:
 - IEC 62386-202:2009 (self-contained emergency lighting)
 - IEC 62386-205:2009 (supply voltage controller for incandescent lamps)
 - IEC 62386-207:2009 (LED modules)
+- IEC 62386-301:2017 (particular requirements for push button input devices)
 
 I do not have copies of the other parts of the standard; they are
 fairly expensive to obtain.  The library is designed to be extensible;
@@ -59,6 +60,10 @@ Library structure
   - ``device`` - DALI control devices as defined in IEC 62386; not stable
 
     - ``general`` - Commands and events from part 103
+
+    - ``pushbutton`` - Commands from part 301
+
+    - ``sequences`` - Packaged sequences for working with DALI control devices
 
   - ``driver`` - Objects to communicate with physical DALI gateways or
     services; not stable
@@ -110,6 +115,8 @@ Contributors
 - Hans Baumgartner
 
 - Ferdinand Keil
+
+- Sean Lanigan, Wallace Building Systems Pty Ltd
 
 
 Copyright

--- a/dali/address.py
+++ b/dali/address.py
@@ -219,6 +219,14 @@ class Instance:
     def add_to_frame(self, f):
         raise NotImplementedError
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            if hasattr(self, "_value") and hasattr(other, "_value"):
+                if self._value == other._value:
+                    return True
+
+        return False
+
 
 class ReservedInstance(Instance):
     """A reserved instance byte."""

--- a/dali/device/__init__.py
+++ b/dali/device/__init__.py
@@ -4,3 +4,6 @@ This module declares commands, responses and event messages defined in
 part 103 ("General requirements - Control devices") and parts 3xx
 (particular requirements for control devices).
 """
+import dali.device.general
+import dali.device.sequences
+import dali.device.pushbutton

--- a/dali/device/__init__.py
+++ b/dali/device/__init__.py
@@ -6,4 +6,4 @@ part 103 ("General requirements - Control devices") and parts 3xx
 """
 import dali.device.general
 import dali.device.sequences
-import dali.device.pushbutton
+import dali.device.pushbutton  # noqa: F401

--- a/dali/device/general.py
+++ b/dali/device/general.py
@@ -967,7 +967,7 @@ class UnknownEvent(_DeviceCommand):
 
 
 class _EventTypeMappingDeviceInstance:
-    def __init__(self, initial = None):
+    def __init__(self, initial=None):
         """
         NOTE: DO NOT create a new instance of this class, use the one already in the
         `dali.general`, i.e. use `general.device_instance_map.add_type()`, or use the

--- a/dali/device/general.py
+++ b/dali/device/general.py
@@ -351,35 +351,35 @@ class QueryDeviceStatus(_StandardDeviceCommand):
 class QueryApplicationControllerError(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponseMask
     _opcode = 0x31
 
 
 class QueryInputDeviceError(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponseMask
     _opcode = 0x32
 
 
 class QueryMissingShortAddress(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x33
 
 
 class QueryVersionNumber(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x34
 
 
 class QueryNumberOfInstances(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x35
 
 
@@ -387,7 +387,7 @@ class QueryContentDTR0(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     uses_dtr0 = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x36
 
 
@@ -395,7 +395,7 @@ class QueryContentDTR1(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     uses_dtr1 = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x37
 
 
@@ -403,28 +403,28 @@ class QueryContentDTR2(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     uses_dtr2 = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x38
 
 
 class QueryRandomAddressH(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x39
 
 
 class QueryRandomAddressM(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x3a
 
 
 class QueryRandomAddressL(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x3b
 
 
@@ -433,14 +433,14 @@ class ReadMemoryLocation(_StandardDeviceCommand):
     inputdev = True
     uses_dtr0 = True
     uses_dtr1 = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x3c
 
 
 class QueryApplicationControlEnabled(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x3d
 
 
@@ -454,14 +454,14 @@ class QueryOperatingMode(_StandardDeviceCommand):
 class QueryManufacturerSpecificMode(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x3f
 
 
 class QueryQuiescentMode(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x40
 
 
@@ -496,7 +496,7 @@ class QueryDeviceGroupsTwentyFourToThirtyOne(_StandardDeviceCommand):
 class QueryPowerCycleNotification(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x45
 
 
@@ -511,14 +511,14 @@ class QueryExtendedVersionNumber(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     uses_dtr0 = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x47
 
 
 class QueryResetState(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x48
 
 
@@ -629,7 +629,7 @@ class SetEventFilter(_StandardInstanceCommand):
 
 class QueryInstanceType(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x80
 
 
@@ -659,7 +659,7 @@ class QueryEventPriority(_StandardInstanceCommand):
 
 class QueryInstanceEnabled(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x86
 
 

--- a/dali/device/general.py
+++ b/dali/device/general.py
@@ -69,10 +69,8 @@ device.device_instance_map.add_type(
 ```
 
 There is also a sequence which will scan the DALI bus and learn the types of all
-enabled instances, `SequenceDiscoverInstanceTypes()`.
+enabled instances, `DiscoverInstanceTypes()`.
 """
-from __future__ import annotations
-
 import types
 from enum import Enum
 from typing import Dict, Optional, Type, Union
@@ -969,7 +967,7 @@ class UnknownEvent(_DeviceCommand):
 
 
 class _EventTypeMappingDeviceInstance:
-    def __init__(self, initial: Optional[Dict[(int, int), int]] = None):
+    def __init__(self, initial = None):
         """
         NOTE: DO NOT create a new instance of this class, use the one already in the
         `dali.general`, i.e. use `general.device_instance_map.add_type()`, or use the
@@ -1222,7 +1220,7 @@ class _Event(_DeviceCommand):
         cls._instance_types[subclass._instance_type] = subclass
 
     @classmethod
-    def from_event_data(cls, event_data: int) -> Type[_Event]:
+    def from_event_data(cls, event_data: int) -> Type["_Event"]:
         """
         Takes a given set of event data, and returns a class which is intended to
         contain that data. For some event types this might just be a mapping, i.e.
@@ -1352,7 +1350,7 @@ class AmbiguousInstanceType(_Event):
         )
 
     @classmethod
-    def from_event_data(cls, event_data: int) -> Type[_Event]:
+    def from_event_data(cls, event_data: int) -> Type["_Event"]:
         return cls
 
     def _set_event_data(self, set_data: Optional[int], set_frame: frame.Frame):

--- a/dali/device/pushbutton.py
+++ b/dali/device/pushbutton.py
@@ -1,0 +1,341 @@
+"""
+Commands, responses and events from IEC 62386 part 301: "Input devices — Push buttons"
+"""
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from dali import command
+from dali.device.general import (
+    DeviceEnum,
+    QueryEventFilterZeroToSeven,
+    _Event,
+    _StandardInstanceCommand,
+)
+
+# "1" corresponds with "Part 301", as per Table 4 of IEC 62386 part 103
+instance_type = 1
+
+
+class _PushbuttonEvent(_Event):
+    """
+    Encodes and decodes messages defined in IEC 62386 part 301. For Push Buttons, the
+    event information uniquely defines an event, i.e. there is no additional data
+    encoded in the event information apart from the event name itself.
+    """
+
+    # "1" corresponds with "Part 301", as per Table 4 of IEC 62386 part 103
+    _instance_type = instance_type
+    _event_classes: Dict[int, Type["_PushbuttonEvent"]] = {}
+
+    @classmethod
+    def _register_subclass(cls, subclass):
+        if not issubclass(subclass, _PushbuttonEvent):
+            raise RuntimeError(
+                "Somehow called _PushbuttonEvent._register_subclass() "
+                "without a subclass of _PushbuttonEvent"
+            )
+        cls._event_classes[subclass._event_info] = subclass
+
+    @classmethod
+    def from_event_data(cls, event_data: int):
+        return cls._event_classes.get(event_data)
+
+
+###############################################################################
+# Commands from Part 301 Table 2 start here
+###############################################################################
+
+
+class ButtonReleased(_PushbuttonEvent):
+    """
+    The button is released
+    """
+
+    _event_info = 0b0000000000
+
+
+class ButtonPressed(_PushbuttonEvent):
+    """
+    The button is pressed
+    """
+
+    _event_info = 0b0000000001
+
+
+class ShortPress(_PushbuttonEvent):
+    """
+    The button is pressed and released, without being pressed quickly again (in case
+    double press is enabled), or the button is pressed and quickly released (in case
+    double press is disabled).
+
+    The Short Timer differentiates a short press from a long press. If a button is
+    released within T_short, either a short or a double press event will follow;
+    otherwise the press will generate a long press event.
+
+    See also: SetShortTimer
+    """
+
+    _event_info = 0b0000000010
+
+
+class DoublePress(_PushbuttonEvent):
+    """
+    The button is pressed and released, quickly followed by another button press.
+
+    The Double Timer (T_double) differentiates a single short press from a double
+    press. If a button is pressed, released, then pressed again within T_double then
+    a double press event is generated. T_double is disabled by setting a value of 0,
+    when disabled a short press event is generated immediately upon button release.
+
+    See also: SetDoubleTimer
+    """
+
+    _event_info = 0b0000000101
+
+
+class LongPressStart(_PushbuttonEvent):
+    """
+    The button is pressed without releasing it.
+
+    The Short Timer (T_short) differentiates a short press from a long press. If a
+    button is released within T_short, either a short or a double press event will
+    follow; otherwise the press will generate a long press event.
+
+    See also: SetShortTimer
+    """
+
+    _event_info = 0b0000001001
+
+
+class LongPressRepeat(_PushbuttonEvent):
+    """
+    Following a long press start condition, the button is still pressed. The event
+    occurs at regular intervals as long as the condition holds.
+
+    The Repeat Timer (T_repeat) sets the repetition interval of long press repeat
+    events.
+
+    See also: SetRepeatTimer
+    """
+
+    _event_info = 0b0000001011
+
+
+class LongPressStop(_PushbuttonEvent):
+    """
+    Following a long press start condition, the button is released. If the long
+    press stop event is enabled, there is no separate button released event.
+    """
+
+    _event_info = 0b0000001100
+
+
+class ButtonFree(_PushbuttonEvent):
+    """
+    The button has been stuck and is now released
+    """
+
+    _event_info = 0b0000001110
+
+
+class ButtonStuck(_PushbuttonEvent):
+    """
+    The button has been pressed for a very long time and is assumed stuck.
+
+    If a button is pressed or bouncing longer than the Stuck Timer (T_stuck) it is
+    considered broken.
+
+    See also: SetStuckTimer
+    """
+
+    _event_info = 0b0000001111
+
+
+###############################################################################
+# Commands from Part 301 Table 10 start here
+###############################################################################
+
+
+class _PushbuttonCommand(_StandardInstanceCommand):
+    """
+    An extension of the standard commands, addressed to a push button control
+    device instance
+    """
+
+    _opcode = None
+
+
+class SetShortTimer(_PushbuttonCommand):
+    """
+    The Short Timer (T_short) differentiates a short press from a long press. If a
+    button is released within T_short, either a short or a double press event will
+    follow; otherwise the press will generate a long press event.
+
+    T_short increments in intervals of 20 ms, i.e. the raw value needs to be
+    multiplied by 20 ms to get the actual value.
+    """
+
+    inputdev = True
+    uses_dtr0 = True
+    sendtwice = True
+    _opcode = 0x00
+
+
+class SetDoubleTimer(_PushbuttonCommand):
+    """
+    The Double Timer (T_double) differentiates a single short press from a double
+    press. If a button is pressed, released, then pressed again within T_double then
+    a double press event is generated. T_double is disabled by setting a value of 0,
+    when disabled a short press event is generated immediately upon button release.
+
+    T_double increments in intervals of 20 ms, i.e. the raw value needs to be
+    multiplied by 20 ms to get the actual value.
+    """
+
+    inputdev = True
+    uses_dtr0 = True
+    sendtwice = True
+    _opcode = 0x01
+
+
+class SetRepeatTimer(_PushbuttonCommand):
+    """
+    The Repeat Timer (T_repeat) sets the repetition interval of long press repeat
+    events.
+
+    T_repeat increments in intervals of 20 ms, i.e. the raw value needs to be
+    multiplied by 20 ms to get the actual value.
+    """
+
+    inputdev = True
+    uses_dtr0 = True
+    sendtwice = True
+    _opcode = 0x02
+
+
+class SetStuckTimer(_PushbuttonCommand):
+    """
+    If a button is pressed or bouncing longer than the Stuck Timer (T_stuck) it is
+    considered broken.
+
+    T_stuck increments in intervals of 1 second, i.e. the raw value is the actual
+    value, in seconds.
+    """
+
+    inputdev = True
+    uses_dtr0 = True
+    sendtwice = True
+    _opcode = 0x03
+
+
+class QueryShortTimer(_PushbuttonCommand):
+    """
+    Gets the current value for T_short.
+
+    See also: SetShortTimer
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0A
+
+
+class QueryShortTimerMin(_PushbuttonCommand):
+    """
+    Gets the minimum value for T_short supported by the hardware
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0B
+
+
+class QueryDoubleTimer(_PushbuttonCommand):
+    """
+    Gets the current value for T_double.
+
+    See also: SetDoubleTimer
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0C
+
+
+class QueryDoubleTimerMin(_PushbuttonCommand):
+    """
+    Gets the minimum value for T_double supported by the hardware.
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0D
+
+
+class QueryRepeatTimer(_PushbuttonCommand):
+    """
+    Gets the current value for T_repeat.
+
+    See also: SetRepeatTimer
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0E
+
+
+class QueryStuckTimer(_PushbuttonCommand):
+    """
+    Gets the current value for T_stuck.
+
+    See also: SetStuckTimer
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0F
+
+
+###############################################################################
+# Event Filters from Part 301 Table 3 start here
+###############################################################################
+
+
+class EventFilterPushbutton(DeviceEnum):
+    """
+    Event Filters for a push button instance, as defined in Part 301 Table 3. The
+    order of the values below correspond to the bit position in the bitmask, from
+    0 to 7 (push button instances only have one byte of event filters defined).
+    """
+
+    button_released = "Button released event enabled"
+    button_pressed = "Button pressed event enabled"
+    short_press = "Short press event enabled"
+    double_press = "Double press event enabled"
+    long_press_start = "Long press start event enabled"
+    long_press_repeat = "Long press repeat event enabled"
+    long_press_stop = "Long press stop event enabled"
+    button_stuck_free = "Button stuck/free event enabled"
+
+
+class QueryEventFilterPushbuttonResponse(command.BitmapResponse):
+    """
+    A response object corresponding to a QueryEventFilterPushbutton message. Internally
+    uses the EventFilterPushbutton enum, i.e. the `status` attribute will be a
+    list of values from this enum.
+    """
+
+    bits = list(EventFilterPushbutton)
+
+
+class QueryEventFilterPushbutton(QueryEventFilterZeroToSeven):
+    """
+    A specific override of the QueryEventFilterZeroToSeven command, tailored to the
+    response expected from a push button instance. There is nothing in a DALI
+    response itself that indicates which instance type was being queried, the type must
+    be known beforehand.
+    """
+
+    no_register = True
+    response = QueryEventFilterPushbuttonResponse

--- a/dali/device/pushbutton.py
+++ b/dali/device/pushbutton.py
@@ -1,8 +1,6 @@
 """
 Commands, responses and events from IEC 62386 part 301: "Input devices — Push buttons"
 """
-from __future__ import annotations
-
 from typing import Dict, Type
 
 from dali import command

--- a/dali/device/sequences.py
+++ b/dali/device/sequences.py
@@ -1,0 +1,212 @@
+"""
+Sequence for simplifying certain interactions with 24-bit DALI devices
+"""
+from __future__ import annotations
+
+from typing import Generator, Iterable, Optional
+
+from dali import address, command, sequences
+from dali.device.general import (
+    DTR0,
+    DeviceStatus,
+    EventScheme,
+    QueryDeviceStatus,
+    QueryDeviceStatusResponse,
+    QueryEventScheme,
+    QueryEventSchemeResponse,
+    QueryInstanceEnabled,
+    QueryInstanceType,
+    QueryNumberOfInstances,
+    SetEventFilter,
+    SetEventScheme,
+    device_instance_map,
+)
+from dali.device.pushbutton import (
+    EventFilterPushbutton,
+    QueryEventFilterPushbutton,
+    QueryEventFilterPushbuttonResponse,
+)
+
+
+def SetEventSchemes(
+    device: address.Short,
+    instance: address.InstanceNumber,
+    scheme: EventScheme,
+) -> Generator[
+    command.Command,
+    Optional[command.Response],
+    Optional[QueryEventSchemeResponse],
+]:
+    """
+    A generator sequence to set the event scheme of a device instance. Use with an
+    appropriate DALI driver instance, through the `run_sequence()` method.
+
+    Returns the event scheme that the target instance actually set.
+
+    Example:
+    ```
+    await driver.run_sequence(
+        SetEventSchemes(
+            device=address.Short(1),
+            instance=address.InstanceNumber(2),
+            scheme=EventScheme.device_instance,
+        )
+    )
+    ```
+    """
+    # Although the proper types are expected, ints are common enough for addresses
+    # and their meaning is unambiguous in this context
+    if isinstance(device, int):
+        device = address.Short(device)
+    if isinstance(instance, int):
+        instance = address.InstanceNumber(instance)
+
+    # The values in EventScheme are mapped by value, only one can be set at a time
+    if not isinstance(scheme, EventScheme):
+        raise ValueError("'scheme' must be an EventScheme enum value")
+
+    pos = scheme.position
+    if not isinstance(pos, int):
+        raise RuntimeError(f"Somehow got an invalid EventScheme position: {pos}")
+
+    rsp = yield DTR0(pos)
+    if rsp is not None:
+        return
+
+    rsp = yield SetEventScheme(device=device, instance=instance)
+    if rsp is not None:
+        return
+
+    rsp = yield QueryEventScheme(device=device, instance=instance)
+    return rsp
+
+
+def DiscoverInstanceTypes(
+    address_count: int = 63,
+) -> Generator[command.Command, command.Response, None,]:
+    """
+    A generator sequence to scan a DALI bus for control device instances, and query
+    their types. This information is added to the `device_instance_map`, for use in
+    decoding "Device/Instance" event messages.
+
+    Example:
+    ```
+    await driver.run_sequence(DiscoverInstanceTypes())
+    ```
+    """
+
+    def check_bad_rsp(r: command.Response) -> bool:
+        if not r:
+            return True
+        if not r.raw_value:
+            return True
+        return False
+
+    for addr_int in range(address_count):
+        addr = address.Short(addr_int)
+
+        # Check that the device exists and responds
+        rsp = yield QueryDeviceStatus(device=addr)
+        if check_bad_rsp(rsp):
+            continue
+        if isinstance(rsp, QueryDeviceStatusResponse):
+            # Make sure the status is OK
+            if (
+                DeviceStatus.input_device_error in rsp.status
+                or DeviceStatus.quiescent_mode in rsp.status
+                or DeviceStatus.address_masked in rsp.status
+                or DeviceStatus.reset_state in rsp.status
+            ):
+                continue
+        else:
+            # If the response isn't QueryDeviceStatusResponse then something is wrong
+            continue
+
+        # Find out how many instances the device has
+        rsp = yield QueryNumberOfInstances(device=addr)
+        if check_bad_rsp(rsp):
+            continue
+        num_inst = rsp.value
+
+        # For each instance, check it is enabled and then query the type
+        for inst_int in range(num_inst):
+            inst = address.InstanceNumber(inst_int)
+            rsp = yield QueryInstanceEnabled(device=addr, instance=inst)
+            if check_bad_rsp(rsp):
+                continue
+            if not rsp.value:
+                # Skip if not enabled
+                continue
+            rsp = yield QueryInstanceType(device=addr, instance=inst)
+            if check_bad_rsp(rsp):
+                continue
+
+            yield sequences.progress(
+                message=f"A²{addr_int} I{inst_int} type: {rsp.value}"
+            )
+
+            # Add the type to the device/instance map
+            device_instance_map.add_type(
+                short_address=addr,
+                instance_number=inst_int,
+                instance_type=rsp.value,
+            )
+
+
+def SetPushbuttonEventFilters(
+    device: address.Short,
+    instance: address.InstanceNumber,
+    filters: Iterable[EventFilterPushbutton],
+) -> Generator[
+    command.Command,
+    Optional[command.Response],
+    Optional[QueryEventFilterPushbuttonResponse],
+]:
+    """
+    A generator sequence to set the event filters of a push button instance. Use with
+    an appropriate DALI driver instance, through the `run_sequence()` method.
+
+    Returns the list of event filters that the target device actually set.
+
+    Example:
+    ```
+        await driver.run_sequence(
+            SetPushbuttonEventFilters(
+                device=address.Short(1),
+                instance=address.InstanceNumber(2),
+                filters=(
+                    EventFilterPushbutton.short_press,
+                    EventFilterPushbutton.double_press,
+                )
+            )
+        )
+    ```
+    """
+    # Although the proper types are expected, ints are common enough for addresses
+    # and their meaning is unambiguous in this context
+    if isinstance(device, int):
+        device = address.Short(device)
+    if isinstance(instance, int):
+        instance = address.InstanceNumber(instance)
+
+    # The values in EventFilterPushbutton are a bit map, the position indicates which
+    # bit to set
+    bits = 0
+    for f in filters:
+        if not isinstance(f, EventFilterPushbutton):
+            raise ValueError(
+                "'filters' must be an iterable of EventFilterPushbutton enum values, "
+                f"not {type(f)}"
+            )
+        bits |= 1 << f.position
+
+    rsp = yield DTR0(bits)
+    if rsp is not None:
+        return
+
+    rsp = yield SetEventFilter(device=device, instance=instance)
+    if rsp is not None:
+        return
+
+    rsp = yield QueryEventFilterPushbutton(device=device, instance=instance)
+    return rsp

--- a/dali/device/sequences.py
+++ b/dali/device/sequences.py
@@ -1,8 +1,6 @@
 """
 Sequence for simplifying certain interactions with 24-bit DALI devices
 """
-from __future__ import annotations
-
 from typing import Generator, Iterable, Optional
 
 from dali import address, command, sequences

--- a/dali/device/sequences.py
+++ b/dali/device/sequences.py
@@ -83,7 +83,7 @@ def SetEventSchemes(
 
 def DiscoverInstanceTypes(
     address_count: int = 63,
-) -> Generator[command.Command, command.Response, None,]:
+) -> Generator[command.Command, command.Response, None]:
     """
     A generator sequence to scan a DALI bus for control device instances, and query
     their types. This information is added to the `device_instance_map`, for use in

--- a/dali/tests/test_command.py
+++ b/dali/tests/test_command.py
@@ -27,6 +27,12 @@ def _test_pattern():
         yield 24, (0xc1, c, 0x00), 0
     for c in (0xc5, 0xc7, 0xc9):
         yield 24, (c, 0x00, 0x00), 0
+    # Control devices, event messages for push buttons (part 301)
+    for e in (0, 1, 2, 5, 9, 11, 12, 14, 15):
+        yield 24, (0xc2, 0x04, e), 0
+    # Control devices, QueryEventFilter
+    for o in (0x90, 0x91, 0x92):
+        yield 24, (0x03, 0x00, o), 0
 
 
 class TestCommands(unittest.TestCase):
@@ -44,6 +50,9 @@ class TestCommands(unittest.TestCase):
                 frame.ForwardFrame(fs, d), devicetype=dt)
             seen[c.__class__] = True
         for cls in command.Command._commands:
+            if hasattr(cls, "no_register"):
+                if cls.no_register:
+                    continue
             self.assertTrue(
                 cls in seen,
                 'class {} not covered by tests'.format(cls.__name__)

--- a/dali/tests/test_events.py
+++ b/dali/tests/test_events.py
@@ -1,0 +1,294 @@
+from dataclasses import dataclass
+from typing import Optional, Type
+
+import pytest
+
+import dali.frame
+from dali import address
+from dali.command import Command
+from dali.device import general, pushbutton
+from dali.device.general import (
+    DTR0,
+    SetEventFilter,
+    _Event,
+    device_instance_map,
+)
+from dali.device.sequences import SetPushbuttonEventFilters
+from dali.device.pushbutton import (
+    EventFilterPushbutton,
+    QueryEventFilterPushbutton,
+    QueryEventFilterPushbuttonResponse,
+)
+
+
+def test_event_base_not_implemented():
+    with pytest.raises(NotImplementedError):
+        general._Event()
+
+
+@pytest.fixture
+def event_test_data_good():
+    @dataclass
+    class EventTestData:
+        event_type: Type[_Event] = pushbutton.ButtonReleased
+        short_address: Optional[int] = None
+        instance_number: Optional[int] = None
+        instance_group: Optional[int] = None
+        device_group: Optional[int] = None
+        frame: str = "000000000000000000000000"
+
+    test_data = (
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_group=2,
+            frame="110001000000010000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_group=31,
+            frame="111111100000010000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_group=0,
+            frame="110000000000010000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_number=2,
+            frame="100000101000100000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_number=31,
+            frame="100000101111110000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ShortPress,
+            instance_group=31,
+            frame="111111100000010000000010",
+        ),
+        EventTestData(
+            event_type=pushbutton.DoublePress,
+            instance_group=31,
+            frame="111111100000010000000101",
+        ),
+        EventTestData(
+            event_type=pushbutton.LongPressStart,
+            device_group=15,
+            frame="100111100000010000001001",
+        ),
+        EventTestData(
+            event_type=pushbutton.LongPressRepeat,
+            device_group=15,
+            frame="100111100000010000001011",
+        ),
+        EventTestData(
+            event_type=pushbutton.LongPressStop,
+            device_group=16,
+            frame="101000000000010000001100",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonPressed,
+            instance_number=17,
+            frame="100000101100010000000001",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            short_address=0,
+            frame="000000000000010000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ShortPress,
+            short_address=63,
+            frame="011111100000010000000010",
+        ),
+    )
+    return test_data
+
+
+def test_event_to_frame_pushbutton_good(event_test_data_good):
+    """
+    Tests a number of values against known-good expected frames, for various
+    pushbutton events
+    """
+    for test_case in event_test_data_good:
+        event = test_case.event_type(
+            short_address=test_case.short_address,
+            instance_number=test_case.instance_number,
+            instance_group=test_case.instance_group,
+            device_group=test_case.device_group,
+        )
+        event_frame = f"{event.frame.as_integer:024b}"
+        assert event_frame == test_case.frame
+
+
+def test_frame_to_event_pushbutton_good(event_test_data_good):
+    """
+    Tests a number of known-good frames, to ensure the correct object is decoded
+    """
+    for test_case in event_test_data_good:
+        test_frame = dali.frame.Frame(24, data=int(test_case.frame, base=2))
+        event = Command.from_frame(test_frame)
+        assert isinstance(event, test_case.event_type)
+        if test_case.short_address:
+            assert event.short_address.address == test_case.short_address
+        assert event.instance_number == test_case.instance_number
+        assert event.instance_group == test_case.instance_group
+        assert event.device_group == test_case.device_group
+
+
+def test_event_repr_short_address():
+    event = pushbutton.ButtonReleased(short_address=1)
+    event_str = f"{event}"
+    assert "ButtonReleased(short_address=1)" == event_str
+
+
+def test_event_repr_instance_number():
+    event = pushbutton.ButtonReleased(instance_number=2)
+    event_str = f"{event}"
+    assert "ButtonReleased(instance_number=2)" == event_str
+
+
+def test_event_repr_instance_group():
+    event = pushbutton.ButtonReleased(instance_group=3)
+    event_str = f"{event}"
+    assert "ButtonReleased(instance_group=3)" == event_str
+
+
+def test_event_repr_device_group():
+    event = pushbutton.ButtonReleased(device_group=31)
+    event_str = f"{event}"
+    assert "ButtonReleased(device_group=31)" == event_str
+
+
+def test_frame_to_ambiguous_event():
+    dev_inst_frame = dali.frame.Frame(24, data=0b000000101000010000000010)
+    decode_cmd = dali.command.Command.from_frame(dev_inst_frame)
+    assert isinstance(decode_cmd, general.AmbiguousInstanceType)
+    assert decode_cmd.short_address.address == 1
+    assert decode_cmd.instance_number == 1
+    assert decode_cmd.event_data == 0b0000000010
+
+
+def test_frame_to_event_dev_inst_pushbutton():
+    device_instance_map.add_type(
+        short_address=1,
+        instance_number=1,
+        instance_type=pushbutton,
+    )
+
+    dev_inst_frame = dali.frame.Frame(24, data=0b000000101000010000000010)
+    decode_cmd = dali.command.Command.from_frame(dev_inst_frame)
+
+    assert isinstance(decode_cmd, pushbutton.ShortPress)
+    assert decode_cmd.short_address.address == 1
+    assert decode_cmd.instance_number == 1
+
+    device_instance_map.clear()
+
+
+def test_event_enum_pushbutton():
+    """
+    Confirms that the custom 'position' attribute of the EventFilterPushbutton
+    enumerator works as expected
+    """
+    assert EventFilterPushbutton.button_released.position == 0
+    assert EventFilterPushbutton.button_pressed.position == 1
+    assert EventFilterPushbutton.short_press.position == 2
+    assert EventFilterPushbutton.double_press.position == 3
+    assert EventFilterPushbutton.long_press_start.position == 4
+    assert EventFilterPushbutton.long_press_repeat.position == 5
+    assert EventFilterPushbutton.long_press_stop.position == 6
+    assert EventFilterPushbutton.button_stuck_free.position == 7
+
+
+def test_event_filter_pushbutton_sequence_partial():
+    """
+    Confirms that the SetEventFilterPushbutton sequence yields the expected DALI
+    message objects and sets the correct bit flags for DTR0
+    """
+    sequence = SetPushbuttonEventFilters(
+        device=address.Short(0),
+        instance=address.InstanceNumber(0),
+        filters={
+            EventFilterPushbutton.button_released,
+            EventFilterPushbutton.button_stuck_free,
+            EventFilterPushbutton.double_press,
+        },
+    )
+    # The first message the sequence should send is DTR0
+    rsp = None
+    try:
+        cmd = sequence.send(rsp)
+    except StopIteration:
+        raise RuntimeError()
+    assert isinstance(cmd, DTR0)
+    assert cmd.frame.as_byte_sequence[2] == 0b10001001
+
+    # The second message should be SetEventFilter
+    try:
+        cmd = sequence.send(rsp)
+    except StopIteration:
+        raise RuntimeError()
+    assert isinstance(cmd, SetEventFilter)
+    assert cmd.destination == address.Short(0)
+    assert cmd.instance == address.InstanceNumber(0)
+
+    # The third message should be QueryEventFilterPushbutton
+    try:
+        cmd = sequence.send(rsp)
+    except StopIteration:
+        raise RuntimeError()
+    assert isinstance(cmd, QueryEventFilterPushbutton)
+
+    # The sequence should then just return whatever the response is
+    rsp = QueryEventFilterPushbuttonResponse(dali.frame.BackwardFrame(0b10001001))
+    ret = None
+    try:
+        sequence.send(rsp)
+    except StopIteration as r:
+        ret = r.value
+    assert isinstance(ret, QueryEventFilterPushbuttonResponse)
+    assert ret == rsp
+    assert EventFilterPushbutton.button_released in ret.status
+    assert EventFilterPushbutton.button_stuck_free in ret.status
+    assert EventFilterPushbutton.double_press in ret.status
+    assert EventFilterPushbutton.short_press not in ret.status
+
+
+def test_event_filter_pushbutton_sequence_all():
+    sequence = SetPushbuttonEventFilters(
+        device=address.Short(0),
+        instance=address.InstanceNumber(0),
+        filters=(
+            EventFilterPushbutton.double_press,
+            EventFilterPushbutton.long_press_start,
+            EventFilterPushbutton.button_pressed,
+            EventFilterPushbutton.short_press,
+            EventFilterPushbutton.long_press_repeat,
+            EventFilterPushbutton.button_released,
+            EventFilterPushbutton.long_press_stop,
+            EventFilterPushbutton.button_stuck_free,
+            EventFilterPushbutton.double_press,  # Intentional duplicate
+        ),
+    )
+    # The first message the sequence should send is DTR0
+    try:
+        cmd = sequence.send(None)
+    except StopIteration:
+        raise RuntimeError()
+    assert isinstance(cmd, DTR0)
+    assert cmd.frame.as_byte_sequence[2] == 0b11111111
+    # The previous test for the sequence adequately checks the remaining logic
+
+
+def test_event_filter_pushbutton_sequence_bad_type():
+    sequence = SetPushbuttonEventFilters(
+        device=address.Short(0),
+        instance=address.InstanceNumber(0),
+        filters=("double_press",),
+    )
+    # Using a string is not valid, it must be an enum object
+    with pytest.raises(ValueError):
+        sequence.send(None)


### PR DESCRIPTION
IEC 62386 part 103 defines "event" messages, which can be sent by control devices to indicate various inputs or changes. This commit introduces support for encoding and decoding these messages, as well as a handful of new sequences for making it easier to work with them.
    
Support has been added for IEC 62386 part 301 "push button" devices, further device types should be simple enough to add in later. Unsupported types will be safely ignored by the library.