### PR TITLE
Add support for DALI 24-bit event messages

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -23,7 +23,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
-          flake8 dali --exclude=driver --count --ignore=E741,F403,F405 --show-source --statistics --max-line-length=127
+          flake8 dali --exclude=driver --count --ignore=E741,F403,F405,W503 --show-source --statistics --max-line-length=127
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           #flake8 dali --exclude=driver --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest

--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ This library has been written with reference to the following documents:
 - IEC 62386-202:2009 (self-contained emergency lighting)
 - IEC 62386-205:2009 (supply voltage controller for incandescent lamps)
 - IEC 62386-207:2009 (LED modules)
+- IEC 62386-301:2017 (particular requirements for push button input devices)
 
 I do not have copies of the other parts of the standard; they are
 fairly expensive to obtain.  The library is designed to be extensible;
@@ -59,6 +60,12 @@ Library structure
   - ``device`` - DALI control devices as defined in IEC 62386; not stable
 
     - ``general`` - Commands and events from part 103
+
+    - ``helpers`` - Useful functions and classes for working with DALI control devices
+
+    - ``pushbutton`` - Commands from part 301
+
+    - ``sequences`` - Packaged sequences for working with DALI control devices
 
   - ``driver`` - Objects to communicate with physical DALI gateways or
     services; not stable
@@ -112,6 +119,8 @@ Contributors
 - Hans Baumgartner
 
 - Ferdinand Keil
+
+- Sean Lanigan, Wallace Building Systems Pty Ltd
 
 
 Copyright

--- a/dali/address.py
+++ b/dali/address.py
@@ -219,6 +219,14 @@ class Instance:
     def add_to_frame(self, f):
         raise NotImplementedError
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            if hasattr(self, "_value") and hasattr(other, "_value"):
+                if self._value == other._value:
+                    return True
+
+        return False
+
 
 class ReservedInstance(Instance):
     """A reserved instance byte."""

--- a/dali/address.py
+++ b/dali/address.py
@@ -101,8 +101,8 @@ class GearBroadcast(GearAddress):
         return "<broadcast (control gear)>"
 
 
-# Broadcast alias provided for legacy purposes, new code should avoid ambiguity by using
-# either GearBroadcast or DeviceBroadcast
+# Broadcast alias provided for legacy purposes, new code should avoid
+# ambiguity by using either GearBroadcast or DeviceBroadcast
 Broadcast = GearBroadcast
 
 
@@ -153,8 +153,9 @@ class GearBroadcastUnaddressed(GearAddress):
         return "<broadcast unaddressed (control gear)>"
 
 
-# BroadcastUnaddressed alias provided for legacy purposes, new code should avoid
-# ambiguity by using either GearBroadcastUnaddressed or DeviceBroadcastUnaddressed
+# BroadcastUnaddressed alias provided for legacy purposes, new code should
+# avoid ambiguity by using either GearBroadcastUnaddressed or
+# DeviceBroadcastUnaddressed
 BroadcastUnaddressed = GearBroadcastUnaddressed
 
 
@@ -213,8 +214,8 @@ class GearGroup(GearAddress):
         return f"<group (control gear) {self.group}>"
 
 
-# Group alias provided for legacy purposes, new code should avoid ambiguity by using
-# either GearGroup or DeviceGroup
+# Group alias provided for legacy purposes, new code should avoid ambiguity
+# by using either GearGroup or DeviceGroup
 Group = GearGroup
 
 
@@ -287,8 +288,8 @@ class GearShort(GearAddress):
         return f"<address (control gear) {self.address}>"
 
 
-# Short alias provided for legacy purposes, new code should avoid ambiguity by using
-# either GearShort or DeviceShort
+# Short alias provided for legacy purposes, new code should avoid ambiguity
+# by using either GearShort or DeviceShort
 Short = GearShort
 
 
@@ -342,6 +343,11 @@ from_frame = Address.from_frame
 class Instance:
     def __init__(self):
         raise NotImplementedError
+
+    @property
+    def value(self):
+        if hasattr(self, "_value"):
+            return self._value
 
     def add_to_frame(self, f):
         raise NotImplementedError

--- a/dali/command.py
+++ b/dali/command.py
@@ -221,7 +221,7 @@ class Command(metaclass=_CommandTracker):
         subs.append(subclass)
 
     @classmethod
-    def from_frame(cls, f, devicetype=0):
+    def from_frame(cls, f, devicetype=0, dev_inst_map=None):
         """Return a Command instance corresponding to the supplied frame.
 
         If the device type the command is intended for is known
@@ -230,6 +230,8 @@ class Command(metaclass=_CommandTracker):
 
         :parameter frame: a forward frame
         :parameter devicetype: type of device frame is intended for
+        :param dev_inst_map: An instance of DeviceInstanceTypeMapper to
+        assist with DALI events
 
         :returns: Return a Command instance corresponding to the
         frame.  Returns None if there is no match.
@@ -241,7 +243,7 @@ class Command(metaclass=_CommandTracker):
         subs = cls._framesizes.get(len(f), [])
 
         for c in subs:
-            r = c.from_frame(f, devicetype=devicetype)
+            r = c.from_frame(f, devicetype=devicetype, dev_inst_map=dev_inst_map)
             if r:
                 return r
 

--- a/dali/command.py
+++ b/dali/command.py
@@ -1,5 +1,6 @@
 """Declaration of base types for dali commands and their responses."""
 
+from enum import IntEnum
 from dali import address
 from dali import frame
 from dali.exceptions import MissingResponse
@@ -156,6 +157,21 @@ class BitmapResponse(Response, metaclass=BitmapResponseBitDict):
         # XXX: be more explicit which exception to catch
         except Exception as e:
             return "{}".format(e)
+
+
+class EnumResponse(Response):
+    """
+    A response that consists of a number from a pre-defined enumerator
+    """
+
+    enumerator: IntEnum = None
+
+    @property
+    def value(self):
+        _value = super().value
+        if _value:
+            return self.enumerator(_value.as_integer)  # noqa
+        return _value
 
 
 class Command(metaclass=_CommandTracker):

--- a/dali/device/__init__.py
+++ b/dali/device/__init__.py
@@ -4,3 +4,6 @@ This module declares commands, responses and event messages defined in
 part 103 ("General requirements - Control devices") and parts 3xx
 (particular requirements for control devices).
 """
+import dali.device.general
+import dali.device.sequences
+import dali.device.pushbutton  # noqa: F401

--- a/dali/device/general.py
+++ b/dali/device/general.py
@@ -40,16 +40,14 @@ An application controller may define up to 32 "instance groups" which
 it may use to address multiple instances at once.  Instances can be
 members of up to three instance groups.
 """
+from enum import IntEnum
 
-from dali import command
-from dali import address
-from dali import frame
+from dali import address, command, frame
 
 
 class _DeviceCommand(command.Command):
     """A command addressed to a control device."""
     _framesize = 24
-
     _devicecommands = []
 
     @classmethod
@@ -72,6 +70,7 @@ class UnknownDeviceCommand(_DeviceCommand):
     def from_frame(cls, f):
         return
 
+
 ###############################################################################
 # Commands from Table 21 start here
 ###############################################################################
@@ -93,7 +92,7 @@ class _StandardDeviceCommand(_DeviceCommand):
 
         self.destination = self._check_destination(device)
 
-        f = frame.ForwardFrame(24, 0x1fe00 | self._opcode)
+        f = frame.ForwardFrame(24, 0x1FE00 | self._opcode)
         self.destination.add_to_frame(f)
 
         super().__init__(f)
@@ -106,7 +105,7 @@ class _StandardDeviceCommand(_DeviceCommand):
 
     @classmethod
     def from_frame(cls, frame):
-        if frame[16:8] != 0x1fe:
+        if frame[16:8] != 0x1FE:
             return
 
         addr = address.from_frame(frame)
@@ -203,7 +202,7 @@ class AddToDeviceGroupsSixteenToThirtyOne(_StandardDeviceCommand):
     uses_dtr1 = True
     uses_dtr2 = True
     sendtwice = True
-    _opcode = 0x1a
+    _opcode = 0x1A
 
 
 class RemoveFromDeviceGroupsZeroToFifteen(_StandardDeviceCommand):
@@ -212,7 +211,7 @@ class RemoveFromDeviceGroupsZeroToFifteen(_StandardDeviceCommand):
     uses_dtr1 = True
     uses_dtr2 = True
     sendtwice = True
-    _opcode = 0x1b
+    _opcode = 0x1B
 
 
 class RemoveFromDeviceGroupsSixteenToThirtyOne(_StandardDeviceCommand):
@@ -221,28 +220,28 @@ class RemoveFromDeviceGroupsSixteenToThirtyOne(_StandardDeviceCommand):
     uses_dtr1 = True
     uses_dtr2 = True
     sendtwice = True
-    _opcode = 0x1c
+    _opcode = 0x1C
 
 
 class StartQuiescentMode(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     sendtwice = True
-    _opcode = 0x1d
+    _opcode = 0x1D
 
 
 class StopQuiescentMode(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     sendtwice = True
-    _opcode = 0x1e
+    _opcode = 0x1E
 
 
 class EnablePowerCycleNotification(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     sendtwice = True
-    _opcode = 0x1f
+    _opcode = 0x1F
 
 
 class DisablePowerCycleNotification(_StandardDeviceCommand):
@@ -259,45 +258,61 @@ class SavePersistentVariables(_StandardDeviceCommand):
     _opcode = 0x21
 
 
+class QueryDeviceStatusResponse(command.BitmapResponse):
+    """
+    Control Device Status, as defined in Part 103 Table 15
+    """
+
+    bits = [
+        "input device error",
+        "quiescent mode enabled",
+        "short address is mask",
+        "application controller active",
+        "application controller error",
+        "power cycle seen",
+        "reset state",
+    ]
+
+
 class QueryDeviceStatus(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = QueryDeviceStatusResponse
     _opcode = 0x30
 
 
 class QueryApplicationControllerError(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponseMask
     _opcode = 0x31
 
 
 class QueryInputDeviceError(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponseMask
     _opcode = 0x32
 
 
 class QueryMissingShortAddress(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x33
 
 
 class QueryVersionNumber(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x34
 
 
 class QueryNumberOfInstances(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x35
 
 
@@ -305,7 +320,7 @@ class QueryContentDTR0(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     uses_dtr0 = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x36
 
 
@@ -313,7 +328,7 @@ class QueryContentDTR1(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     uses_dtr1 = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x37
 
 
@@ -321,29 +336,29 @@ class QueryContentDTR2(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     uses_dtr2 = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x38
 
 
 class QueryRandomAddressH(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x39
 
 
 class QueryRandomAddressM(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
-    _opcode = 0x3a
+    response = command.NumericResponse
+    _opcode = 0x3A
 
 
 class QueryRandomAddressL(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
-    _opcode = 0x3b
+    response = command.NumericResponse
+    _opcode = 0x3B
 
 
 class ReadMemoryLocation(_StandardDeviceCommand):
@@ -351,77 +366,89 @@ class ReadMemoryLocation(_StandardDeviceCommand):
     inputdev = True
     uses_dtr0 = True
     uses_dtr1 = True
-    response = command.Response
-    _opcode = 0x3c
+    response = command.NumericResponse
+    _opcode = 0x3C
 
 
 class QueryApplicationControlEnabled(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
-    _opcode = 0x3d
+    response = command.YesNoResponse
+    _opcode = 0x3D
 
 
 class QueryOperatingMode(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
-    _opcode = 0x3e
+    response = command.NumericResponse
+    _opcode = 0x3E
 
 
 class QueryManufacturerSpecificMode(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
-    _opcode = 0x3f
+    response = command.YesNoResponse
+    _opcode = 0x3F
 
 
 class QueryQuiescentMode(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x40
 
 
 class QueryDeviceGroupsZeroToSeven(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x41
 
 
 class QueryDeviceGroupsEightToFifteen(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x42
 
 
 class QueryDeviceGroupsSixteenToTwentyThree(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x43
 
 
 class QueryDeviceGroupsTwentyFourToThirtyOne(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x44
 
 
 class QueryPowerCycleNotification(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x45
+
+
+class QueryDeviceCapabilitiesResponse(command.BitmapResponse):
+    """
+    Control Device Capabilities, as defined in Part 103 Table 14
+    """
+
+    bits = [
+        "application controller present",
+        "number instances greater than zero",
+        "application controller always active",
+    ]
 
 
 class QueryDeviceCapabilities(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = QueryDeviceCapabilitiesResponse
     _opcode = 0x46
 
 
@@ -429,19 +456,20 @@ class QueryExtendedVersionNumber(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
     uses_dtr0 = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x47
 
 
 class QueryResetState(_StandardDeviceCommand):
     appctrl = True
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x48
 
 
 class _StandardInstanceCommand(_DeviceCommand):
     """A standard command addressed to a control device instance."""
+
     _opcode = None
 
     def __init__(self, device, instance):
@@ -544,91 +572,122 @@ class SetEventFilter(_StandardInstanceCommand):
 
 class QueryInstanceType(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x80
 
 
 class QueryResolution(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x81
 
 
 class QueryInstanceError(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x82
+
+
+class QueryInstanceStatusResponse(command.BitmapResponse):
+    """
+    Instance Status, as defined in Part 103 Table 16
+    """
+
+    bits = [
+        "instance error",
+        "instance active",
+    ]
 
 
 class QueryInstanceStatus(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = QueryInstanceStatusResponse
     _opcode = 0x83
 
 
 class QueryEventPriority(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x84
 
 
 class QueryInstanceEnabled(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.YesNoResponse
     _opcode = 0x86
 
 
 class QueryPrimaryInstanceGroup(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x88
 
 
 class QueryInstanceGroup1(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x89
 
 
 class QueryInstanceGroup2(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
-    _opcode = 0x8a
+    response = command.NumericResponse
+    _opcode = 0x8A
+
+
+class EventScheme(IntEnum):
+    """
+    Event Address Scheme setting values, as defined in Part 103 Table 8
+    """
+
+    instance = 0
+    device = 1
+    device_instance = 2
+    device_group = 3
+    instance_group = 4
+
+
+class QueryEventSchemeResponse(command.EnumResponse):
+    """
+    A response object corresponding to a QueryEventScheme message
+    """
+
+    enumerator = EventScheme
 
 
 class QueryEventScheme(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
-    _opcode = 0x8b
+    response = QueryEventSchemeResponse
+    _opcode = 0x8B
 
 
 class QueryInputValue(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
-    _opcode = 0x8c
+    response = command.NumericResponse
+    _opcode = 0x8C
 
 
 class QueryInputValueLatch(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
-    _opcode = 0x8d
+    response = command.NumericResponse
+    _opcode = 0x8D
 
 
 class QueryFeatureType(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
-    _opcode = 0x8e
+    response = command.NumericResponse
+    _opcode = 0x8E
 
 
 class QueryNextFeatureType(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
-    _opcode = 0x8f
+    response = command.NumericResponse
+    _opcode = 0x8F
 
 
 class QueryEventFilterZeroToSeven(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x90
 
 
@@ -637,7 +696,7 @@ QueryEventFilterL = QueryEventFilterZeroToSeven
 
 class QueryEventFilterEightToFifteen(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x91
 
 
@@ -646,7 +705,7 @@ QueryEventFilterM = QueryEventFilterEightToFifteen
 
 class QueryEventFilterSixteenToTwentyThree(_StandardInstanceCommand):
     inputdev = True
-    response = command.Response
+    response = command.NumericResponse
     _opcode = 0x92
 
 
@@ -725,100 +784,100 @@ class _SpecialDeviceCommandTwoParam(_SpecialDeviceCommand):
 
 
 class Terminate(_SpecialDeviceCommand):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x00
 
 
 class Initialise(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x01
     sendtwice = True
 
 
 class Randomise(_SpecialDeviceCommand):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x02
     sendtwice = True
 
 
 class Compare(_SpecialDeviceCommand):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x03
-    response = command.Response
+    response = command.YesNoResponse
 
 
 class Withdraw(_SpecialDeviceCommand):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x04
 
 
 class SearchAddrH(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x05
 
 
 class SearchAddrM(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x06
 
 
 class SearchAddrL(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x07
 
 
 class ProgramShortAddress(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x08
 
 
 class VerifyShortAddress(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x09
-    response = command.Response
+    response = command.YesNoResponse
 
 
 class QueryShortAddress(_SpecialDeviceCommand):
-    _addr = 0xc1
-    _instance = 0x0a
-    response = command.Response
+    _addr = 0xC1
+    _instance = 0x0A
+    response = command.NumericResponse
 
 
 class WriteMemoryLocation(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x20
     uses_dtr0 = True
     uses_dtr1 = True
-    response = command.Response
+    response = command.NumericResponse
 
 
 class WriteMemoryLocationNoReply(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x21
     uses_dtr0 = True
     uses_dtr1 = True
 
 
 class DTR0(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x30
     uses_dtr0 = True
 
 
 class DTR1(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x31
     uses_dtr1 = True
 
 
 class DTR2(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x32
     uses_dtr2 = True
 
 
 class SendTestframe(_SpecialDeviceCommandOneParam):
-    _addr = 0xc1
+    _addr = 0xC1
     _instance = 0x33
     uses_dtr0 = True
     uses_dtr1 = True
@@ -826,19 +885,19 @@ class SendTestframe(_SpecialDeviceCommandOneParam):
 
 
 class DirectWriteMemory(_SpecialDeviceCommandTwoParam):
-    _addr = 0xc5
+    _addr = 0xC5
     uses_dtr0 = True
     uses_dtr1 = True
-    response = command.Response
+    response = command.NumericResponse
 
 
 class DTR1DTR0(_SpecialDeviceCommandTwoParam):
-    _addr = 0xc7
+    _addr = 0xC7
     uses_dtr0 = True
     uses_dtr1 = True
 
 
 class DTR2DTR1(_SpecialDeviceCommandTwoParam):
-    _addr = 0xc9
+    _addr = 0xC9
     uses_dtr1 = True
     uses_dtr2 = True

--- a/dali/device/general.py
+++ b/dali/device/general.py
@@ -757,6 +757,10 @@ class _SpecialDeviceCommandOneParam(_SpecialDeviceCommand):
         if frame[23:16] == cls._addr and frame[15:8] == cls._instance:
             return cls(frame[7:0])
 
+    @property
+    def param(self) -> int:
+        return self._opcode
+
     def __str__(self):
         return "{}({:02x})".format(self.__class__.__name__, self._opcode)
 
@@ -777,6 +781,14 @@ class _SpecialDeviceCommandTwoParam(_SpecialDeviceCommand):
             return
         if frame[23:16] == cls._addr:
             return cls(frame[15:8], frame[7:0])
+
+    @property
+    def param_1(self) -> int:
+        return self._instance
+
+    @property
+    def param_2(self) -> int:
+        return self._opcode
 
     def __str__(self):
         return "{}({:02x}, {:02x})".format(

--- a/dali/device/general.py
+++ b/dali/device/general.py
@@ -39,10 +39,23 @@ Instances have:
 An application controller may define up to 32 "instance groups" which
 it may use to address multiple instances at once.  Instances can be
 members of up to three instance groups.
+
+
+Event messages are supported as per part 103, with specific event types
+implemented in relevant submodules, e.g. pushbutton.py for part 301.
+
+Messages which have no implementation will still be decoded, but will be
+interpreted as an "UnknownEvent" object.
 """
-from enum import IntEnum
+from __future__ import annotations
+
+from enum import IntEnum, IntFlag
+from typing import Optional, TYPE_CHECKING, Type
 
 from dali import address, command, frame
+
+if TYPE_CHECKING:
+    from dali.device.helpers import DeviceInstanceTypeMapper
 
 
 class _DeviceCommand(command.Command):
@@ -55,9 +68,12 @@ class _DeviceCommand(command.Command):
         cls._devicecommands.append(subclass)
 
     @classmethod
-    def from_frame(cls, f, devicetype=0):
+    def from_frame(cls, f, devicetype=0, dev_inst_map=None):
+        # In 24-bit frames, bit 16 is 1 for "commands" (as opposed to "events")
+        if not f[16]:
+            return
         for dc in cls._devicecommands:
-            r = dc.from_frame(f)
+            r = dc.from_frame(f, dev_inst_map=dev_inst_map)
             if r:
                 return r
         return UnknownDeviceCommand(f)
@@ -67,8 +83,34 @@ class UnknownDeviceCommand(_DeviceCommand):
     """An unknown command addressed to a control device.
     """
     @classmethod
-    def from_frame(cls, f):
+    def from_frame(cls, f, devicetype=0, dev_inst_map=None):
         return
+
+
+class InstanceEventFilter(IntFlag):
+    """
+    A base class for implementing specific event filters, which are used by
+    each different instance type. Flags in an InstanceEventFilter enum *must*
+    only be powers of two, i.e. each bit can only be named once and there cannot
+    be named groups of bits.
+    """
+
+    @classmethod
+    def dali_width(cls) -> int:
+        """Indicates if 8, 16, or 24 bits are needed for this event filter"""
+
+        length = len(cls)
+        if length <= 8:
+            return 8
+        elif length <= 16:
+            return 16
+        elif length <= 24:
+            return 24
+        else:
+            raise TypeError(
+                f"{cls.__name__} from {cls.__module__} has more than 24 bits "
+                "defined, this is not allowed"
+            )
 
 
 ###############################################################################
@@ -104,18 +146,18 @@ class _StandardDeviceCommand(_DeviceCommand):
         cls._opcodes[subclass._opcode] = subclass
 
     @classmethod
-    def from_frame(cls, frame):
-        if frame[16:8] != 0x1FE:
+    def from_frame(cls, f, devicetype=0, dev_inst_map=None):
+        if f[16:8] != 0x1FE:
             return
 
-        addr = address.from_frame(frame)
+        addr = address.from_frame(f)
 
         if addr is None:
             return
 
-        cc = cls._opcodes.get(frame[7:0])
+        cc = cls._opcodes.get(f[7:0])
         if not cc:
-            return UnknownDeviceCommand(frame)
+            return UnknownDeviceCommand(f)
 
         return cc(addr)
 
@@ -487,25 +529,26 @@ class _StandardInstanceCommand(_DeviceCommand):
 
         super().__init__(f)
 
-    _opcodes = {}
+    _opcodes: dict[int, Type[_StandardInstanceCommand]] = dict()
 
     @classmethod
-    def _register_subclass(cls, subclass):
+    def _register_subclass(cls, subclass: Type[_StandardInstanceCommand]):
         cls._opcodes[subclass._opcode] = subclass
 
     @classmethod
-    def from_frame(cls, frame):
-        if not frame[16]:
+    def from_frame(cls, f, devicetype=0, dev_inst_map=None):
+        # In 24-bit frames, bit 16 is 1 for "commands" (as opposed to "events")
+        if not f[16]:
             return
-        addr = address.from_frame(frame)
-        instance = address.instance_from_frame(frame)
+        addr = address.from_frame(f)
+        instance = address.instance_from_frame(f)
 
         if addr is None or instance is None:
             return
 
-        cc = cls._opcodes.get(frame[7:0])
+        cc = cls._opcodes.get(f[7:0])
         if not cc:
-            return UnknownDeviceCommand(frame)
+            return UnknownDeviceCommand(f)
 
         return cc(addr, instance)
 
@@ -726,15 +769,14 @@ class _SpecialDeviceCommand(_DeviceCommand):
         if self._addr is None or self._instance is None:
             raise NotImplementedError
         super().__init__(
-            frame.ForwardFrame(24, (
-                self._addr, self._instance, self._opcode)))
+            frame.ForwardFrame(24, (self._addr, self._instance, self._opcode))
+        )
 
     @classmethod
-    def from_frame(cls, frame):
+    def from_frame(cls, f, devicetype=0, dev_inst_map=None):
         if cls == _SpecialDeviceCommand:
             return
-        if frame[23:16] == cls._addr and frame[15:8] == cls._instance \
-           and frame[7:0] == 0x00:
+        if f[23:16] == cls._addr and f[15:8] == cls._instance and f[7:0] == 0x00:
             return cls()
 
     def __str__(self):
@@ -751,11 +793,11 @@ class _SpecialDeviceCommandOneParam(_SpecialDeviceCommand):
         super().__init__()
 
     @classmethod
-    def from_frame(cls, frame):
+    def from_frame(cls, f, devicetype=0, dev_inst_map=None):
         if cls == _SpecialDeviceCommandOneParam:
             return
-        if frame[23:16] == cls._addr and frame[15:8] == cls._instance:
-            return cls(frame[7:0])
+        if f[23:16] == cls._addr and f[15:8] == cls._instance:
+            return cls(f[7:0])
 
     @property
     def param(self) -> int:
@@ -776,11 +818,11 @@ class _SpecialDeviceCommandTwoParam(_SpecialDeviceCommand):
         super().__init__()
 
     @classmethod
-    def from_frame(cls, frame):
+    def from_frame(cls, f, devicetype=0, dev_inst_map=None):
         if cls == _SpecialDeviceCommandTwoParam:
             return
-        if frame[23:16] == cls._addr:
-            return cls(frame[15:8], frame[7:0])
+        if f[23:16] == cls._addr:
+            return cls(f[15:8], f[7:0])
 
     @property
     def param_1(self) -> int:
@@ -913,3 +955,416 @@ class DTR2DTR1(_SpecialDeviceCommandTwoParam):
     _addr = 0xC9
     uses_dtr1 = True
     uses_dtr2 = True
+
+
+class _Event(command.Command):
+    """
+    An event message from a control device
+    """
+
+    # 'enabled_by' holds a reference to an element in an enum which, when used
+    # with the appropriate 'SetEventFilter' sequence, flags if this event is
+    # enabled
+    enabled_by: Optional[IntEnum] = None
+
+    _framesize = 24
+    # The metaclass will call '_register_subclass()', which then adds to this
+    # dict to maintain a mapping of 'instance type' codes to the Python class
+    # which implements that type
+    _instance_types: dict[int, Type[_Event]] = {}
+
+    # Identifying information, not all will be present for each message
+    _short_address = None
+    _instance_number = None
+    _instance_group = None
+    _device_group = None
+    # Instance Type and Event Info will be overridden in subclasses
+    _instance_type = None
+    _event_info = None
+    _data = None
+
+    def __init__(
+        self,
+        *,
+        short_address: Optional[address.DeviceShort | int] = None,
+        instance_number: Optional[int] = None,
+        instance_group: Optional[int] = None,
+        device_group: Optional[int] = None,
+        data: Optional[int] = None,
+    ):
+        if isinstance(self, (AmbiguousInstanceType, UnknownEvent)):
+            # Start with an empty frame for these edge-case types, the rest will
+            # be filled in later to make the frame survive a round-trip
+            f = frame.ForwardFrame(24, 0)
+        elif self._event_info is None:
+            raise NotImplementedError
+        else:
+            f = frame.ForwardFrame(24, self._event_info)
+
+        if short_address is not None:
+            # If specifying short address, the instance type is implicitly known
+            # already through the class type. Other properties are not allowed.
+            if device_group is not None:
+                raise ValueError(
+                    "Must not specify 'device group' with 'short address'"
+                )
+            elif instance_group is not None:
+                raise ValueError(
+                    "Must not specify 'instance group' with 'short address'"
+                )
+
+            if instance_number is None:
+                # Using "Device" scheme
+                f[14:10] = self.instance_type
+                # 'Device' scheme: bit 23 = 0, bit 15 = 0
+                f[23] = False
+                f[15] = False
+            else:
+                # Using "Device/Instance" scheme
+                self._instance_number = instance_number
+                f[14:10] = instance_number
+                # 'Device/Instance' scheme: bit 23 = 0, bit 15 = 1
+                f[23] = False
+                f[15] = True
+
+            if isinstance(short_address, address.DeviceShort):
+                self._short_address = short_address
+            else:
+                self._short_address = address.DeviceShort(short_address)
+            self.short_address.add_to_frame(f)
+
+        elif device_group is not None:
+            # If specifying device group, the instance type is implicitly
+            # known already through the class type. Other properties are not
+            # allowed.
+            if instance_number is not None:
+                raise ValueError(
+                    "Must not specify 'instance number' with 'device group'"
+                )
+            elif instance_group is not None:
+                raise ValueError(
+                    "Must not specify 'instance group' with 'device group'"
+                )
+            self._device_group = device_group
+            # In the 'device group' scheme, the instance type is in bits 14:10
+            f[14:10] = self.instance_type
+            # Then the device group is bits 21:17
+            f[21:17] = device_group
+            # 'device group' scheme: bit 23 = 1, bit 22 = 0, bit 15 = 0
+            f[23] = True
+            f[22] = False
+            f[15] = False
+
+        elif instance_group is not None:
+            # If specifying instance group, the instance type is implicitly
+            # known already through the class type. Other properties are not
+            # allowed.
+            if instance_number is not None:
+                raise ValueError(
+                    "Must not specify 'instance number' with 'instance group'"
+                )
+            self._instance_group = instance_group
+            # In the 'instance group' scheme, the instance type is in bits 14:10
+            f[14:10] = self.instance_type
+            # Then the instance group is in bits 21:17
+            f[21:17] = instance_group
+            # 'instance group' scheme: bit 23 = 1, bit 22 = 1, bit 15 = 0
+            f[23] = True
+            f[22] = True
+            f[15] = False
+
+        elif instance_number is not None:
+            # If specifying instance number, the instance type is implicitly
+            # known already through the class type. Other properties are not
+            # allowed, these have been checked already in the previous
+            # statements.
+            self._instance_number = instance_number
+            # In the 'instance' scheme, the instance type is in bits 21:17
+            f[21:17] = self.instance_type
+            # Then the instance number is in bits 14:10
+            f[14:10] = instance_number
+            # 'instance' scheme: bit 23 = 1, bit 22 = 0, bit 15 = 1
+            f[23] = True
+            f[22] = False
+            f[15] = True
+
+        else:
+            raise ValueError(
+                "No valid combination of 'instance number', 'short address', "
+                "'device group' or 'instance group'"
+            )
+
+        self._set_event_data(data, f)
+        super().__init__(f)
+
+    def _set_event_data(self, set_data: int, set_frame: frame.Frame):
+        """
+        Overridden in subclasses which have data to include in the 10 bits of
+        event information, by default does nothing
+        """
+        return
+
+    @property
+    def event_data(self):
+        """
+        Overridden in subclasses which have data, primarily used to format
+        data in a suitable way for the __repr__ method
+        """
+        return
+
+    @property
+    def short_address(self) -> Optional[address.DeviceShort]:
+        return self._short_address
+
+    @property
+    def instance_type(self) -> int:
+        return self._instance_type
+
+    @property
+    def device_group(self) -> Optional[int]:
+        return self._device_group
+
+    @property
+    def instance_group(self) -> Optional[int]:
+        return self._instance_group
+
+    @property
+    def instance_number(self) -> Optional[int]:
+        return self._instance_number
+
+    @classmethod
+    def _register_subclass(cls, subclass):
+        if not issubclass(subclass, _Event):
+            raise RuntimeError(
+                "Somehow called _Event._register_subclass() "
+                "without a subclass of _Event"
+            )
+        # Don't register UnknownEvent, no message should be decoded as this
+        if subclass.__name__ == "UnknownEvent":
+            return
+        cls._instance_types[subclass._instance_type] = subclass
+
+    @classmethod
+    def get_instance_type_class(
+        cls, instance_type: int
+    ) -> Optional[Type[_Event]]:
+        return cls._instance_types.get(instance_type)
+
+    @classmethod
+    def from_event_data(cls, event_data: int) -> Type[_Event]:
+        """
+        Takes a given set of event data, and returns a class which is
+        intended to contain that data. For some event types this might just
+        be a mapping, i.e. for events where each possible value represents a
+        different event. For some other events which have data, the returned
+        class could be the same for multiple data.
+        """
+        raise NotImplementedError(
+            "'from_event_data()' must be implemented in a subclass"
+        )
+
+    @classmethod
+    def from_frame(
+        cls,
+        f: frame.Frame,
+        devicetype: int = 0,
+        dev_inst_map: DeviceInstanceTypeMapper = None,
+    ):
+        # In 24-bit frames, bit 16 is 0 for "events"
+        if f[16] != 0:
+            return
+
+        short_address = None
+        instance_number = None
+        instance_group = None
+        device_group = None
+        data = f[9:0]
+
+        # Refer to Part 103 Table 3, Event Scheme / Source identification
+        if f[23] == 0 and f[15] == 0:
+            # "Device", has short address and instance type. This means the
+            # event information can be decoded without further context.
+            instance_type = f[14:10]
+            short_address = address.DeviceShort(f[22:17])
+        elif f[23] == 0 and f[15] == 1:
+            # "Device/instance", has short address and instance number.
+            # NOTE: Further contextual information is needed to decode,
+            # since the event information cannot be inferred just from this
+            # message alone!
+            instance_number = f[14:10]
+            short_address = address.DeviceShort(f[22:17])
+
+            if dev_inst_map is not None:
+                instance_type = dev_inst_map.get_type(
+                    short_address=short_address, instance_number=instance_number
+                )
+            else:
+                instance_type = None
+            if instance_type is None:
+                # Since this message can't be handled, even though we know it
+                # is some sort of event message, return an
+                # 'AmbiguousInstanceType'
+                return AmbiguousInstanceType(
+                    short_address=short_address,
+                    instance_number=instance_number,
+                    data=data,
+                )
+        elif f[23] == 1 and f[22] == 0 and f[15] == 0:
+            # "Device group", has device group and instance type. The event
+            # information can be decoded without further context.
+            instance_type = f[14:10]
+            device_group = f[21:17]
+        elif f[23] == 1 and f[22] == 0 and f[15] == 1:
+            # "Instance", has instance type and instance number. The event
+            # information can be decoded without further context.
+            instance_type = f[21:17]
+            instance_number = f[14:10]
+        elif f[23] == 1 and f[22] == 1 and f[15] == 0:
+            # "Instance group", has instance group and instance type. The event
+            # information can be decoded without further context.
+            instance_type = f[14:10]
+            instance_group = f[21:17]
+        else:
+            # This message is not an event message
+            return
+
+        instance_type_class = cls.get_instance_type_class(instance_type)
+        if instance_type_class is not None:
+            event_type = instance_type_class.from_event_data(data)
+            if event_type is not None:
+                return event_type(
+                    short_address=short_address,
+                    instance_number=instance_number,
+                    instance_group=instance_group,
+                    device_group=device_group,
+                    data=data,
+                )
+
+        # Even though we know this is an event message of some sort, there
+        # seemingly isn't the code to handle it
+        return UnknownEvent(
+            instance_type=instance_type,
+            short_address=short_address,
+            instance_number=instance_number,
+            instance_group=instance_group,
+            device_group=device_group,
+            data=data,
+        )
+
+    def __str__(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        rep_str = f"{self.__class__.__name__}("
+        if self.short_address:
+            rep_str += f"short_address={self.short_address.address}, "
+        if self.instance_number is not None:
+            rep_str += f"instance_number={self.instance_number}, "
+        if self.instance_group is not None:
+            rep_str += f"instance_group={self.instance_group}, "
+        if self.device_group is not None:
+            rep_str += f"device_group={self.device_group}, "
+        if self.event_data is not None:
+            rep_str += f"data={self.event_data}, "
+        # Remove the final ", " characters
+        rep_str = rep_str[:-2]
+        rep_str += ")"
+
+        return rep_str
+
+
+class UnknownEvent(_Event):
+    """
+    A message known to be an "event", but with no specific implementation
+    in this library
+    """
+
+    def __init__(self, instance_type: int = 0, **kwargs):
+        self._instance_type = instance_type
+        super().__init__(**kwargs)
+
+    def _set_event_data(self, set_data: Optional[int], set_frame: frame.Frame):
+        """
+        Even though the event information can't be decoded because the
+        event type is not understood, the information can still be stored into
+        the frame
+        """
+        if set_data is not None:
+            set_frame[9:0] = set_data
+
+    @classmethod
+    def from_frame(cls, f, devicetype=0, dev_inst_map=None):
+        return
+
+
+class AmbiguousInstanceType(_Event):
+    """
+    A message which is known to be an "event" using the "Device/Instance"
+    scheme, but the mapping from device and instance to a concrete instance
+    type has not previously been defined. When this happens the event
+    information cannot be decoded at all, because the meaning of the event
+    information depends on the instance type.
+
+    Mappings of device/instance to event types can be set up using a
+    `device_instance_map.add_type()` call, or use the sequence
+    `DiscoverInstanceTypes()`.
+    """
+
+    def __init__(self, **kwargs):
+        short_address = kwargs.pop("short_address")
+        if short_address is None:
+            raise ValueError(
+                "'short_address' is required for AmbiguousInstanceType"
+            )
+        instance_number = kwargs.pop("instance_number")
+        if instance_number is None:
+            raise ValueError(
+                "'instance_number' is required for AmbiguousInstanceType"
+            )
+        data = kwargs.pop("data", None)
+        self._unhandled_data = None
+        super().__init__(
+            short_address=short_address,
+            instance_number=instance_number,
+            data=data,
+        )
+
+    @classmethod
+    def from_event_data(cls, event_data: int) -> Type[_Event]:
+        return cls
+
+    def _set_event_data(self, set_data: Optional[int], set_frame: frame.Frame):
+        """
+        Even though the event information can't be decoded because the
+        instance type is not known, the information can still be stored into
+        the frame
+        """
+        if set_data is not None:
+            self._unhandled_data = set_data
+            set_frame[9:0] = set_data
+
+    @property
+    def event_data(self):
+        return self._unhandled_data
+
+    def retry_decode(
+        self, dev_inst_map: DeviceInstanceTypeMapper
+    ) -> Optional[_Event]:
+        """
+        Tries to decode this ambiguous instance message, using the additional
+        information contained in the provided DeviceInstanceTypeMapper
+        object. This might make it possible to decipher this event message
+        into a specific instance event.
+
+        :param dev_inst_map: A relevant DeviceInstanceTypeMapper object to
+        use, e.g. previously created through scanning and querying devices on
+        the same DALI bus
+        :return: If the event could be deciphered specifically through the
+        additional information then a new event object will be returned,
+        otherwise None
+        """
+        retried = command.Command.from_frame(
+            self.frame, devicetype=self.devicetype, dev_inst_map=dev_inst_map
+        )
+        if not isinstance(retried, AmbiguousInstanceType):
+            return retried

--- a/dali/device/helpers.py
+++ b/dali/device/helpers.py
@@ -1,0 +1,232 @@
+"""
+Helper functions and classes, used in various other places through the library
+"""
+from __future__ import annotations
+
+import types
+from typing import Generator, Iterable, Optional
+
+from dali.address import DeviceShort, InstanceNumber
+from dali.command import Command, Response
+from dali.device.general import (
+    QueryDeviceStatus,
+    QueryDeviceStatusResponse,
+    QueryInstanceEnabled,
+    QueryInstanceType,
+    QueryNumberOfInstances,
+)
+from dali.exceptions import MissingResponse, ResponseError
+from dali.frame import BackwardFrameError
+from dali.sequences import progress as seq_progress
+
+
+def check_bad_rsp(r: Response | None) -> bool:
+    """
+    Checks if a response is "bad", i.e. if it is missing, is an error, or does
+    not have a value when one is expected.
+
+    :param r: A Response object to check
+    :return: A boolean, True if the response is "bad"
+    """
+    if not r:
+        return True
+    if isinstance(r.raw_value, BackwardFrameError):
+        return True
+    try:
+        # The 'value' property raises an exception if a value is expected but
+        # not present (except for NumericResponse)
+        val = r.value
+        # A NumericResponse uses strings to indicate error state
+        if isinstance(val, str):
+            if "missing" in val:
+                return True
+            if "framing error" in val:
+                return True
+    except (MissingResponse, ResponseError):
+        return True
+
+    return False
+
+
+class DeviceInstanceTypeMapper:
+    """
+    Part 103 defines five different event message addressing schemes, as per
+    Table 8 of IEC 62386.103. These are: "Instance", "Device",
+    "Device/Instance", "Device Group" and "Instance Group". Four of these
+    only rely on data contained within the message itself, however the
+    "Device/Instance" addressing scheme does not include information in the
+    24 bits of the message to indicate the instance type - which means that
+    without further knowledge it is not possible to decode these messages.
+
+    DeviceInstanceTypeMapper stores a mapping from the address and instance
+    number of a device to the instance type, thus allowing a higher-level
+    system to decode "Device/Instance" messages.
+
+    One instance of DeviceInstanceTypeMapper should be created for each DALI
+    bus, and then re-used whenever decoding event messages from that bus
+    through the `from_frame()` method.
+    """
+
+    def __init__(self, initial=None):
+        """
+        Creates a new DeviceInstanceTypeMapper object, optionally with
+        preloaded mappings as defined by `initial`.
+
+        :param initial: A dict of data to preload into the mapping
+        """
+        self._mapping: dict[(int, int), int] = {}
+        if initial:
+            self._mapping = initial
+
+    @property
+    def mapping(self) -> dict[(int, int), int]:
+        return self._mapping
+
+    def autodiscover(
+        self, addresses: int | tuple[int, int] | Iterable[int] = (0, 63)
+    ) -> Generator[Command, Response, None]:
+        """
+        A generator sequence to scan a DALI bus for control device instances,
+        and query their types. This information is stored within this
+        DeviceInstanceTypeMapper, for use in decoding "Device/Instance" event
+        messages.
+
+        :param addresses: Optional specifier of which addresses to scan. Can
+        either be a single int, in which case all addresses from zero to that
+        value will be scanned; or can be a tuple in the form (start, end), in
+        which case all addresses between the provided values will be scanned;
+        or finally can be an iterable of ints in which case each address, in
+        the iterator will be scanned.
+        :return: A generator function, to use with e.g. `driver.run_sequence()`
+
+        Needs to be used through an appropriate driver, with `run_sequence()`,
+        for example:
+        ```
+        dev_inst_map = DeviceInstanceTypeMapper()
+        await driver.run_sequence(dev_inst_map.autodiscover())
+        ```
+        """
+
+        if isinstance(addresses, int):
+            addresses = (n for n in range(0, addresses))
+        elif isinstance(addresses, tuple) and len(addresses) == 2:
+            addresses = (n for n in range(addresses[0], addresses[1] + 1))
+
+        for addr_int in addresses:
+            addr = DeviceShort(addr_int)
+
+            # Check that the device exists and responds
+            rsp = yield QueryDeviceStatus(device=addr)
+            if check_bad_rsp(rsp):
+                continue
+            if isinstance(rsp, QueryDeviceStatusResponse):
+                # Make sure the status is OK
+                if (
+                    rsp.input_device_error
+                    or rsp.quiescent_mode_enabled
+                    or rsp.short_address_is_mask
+                    or rsp.reset_state
+                ):
+                    continue
+            else:
+                # If the response isn't QueryDeviceStatusResponse then
+                # something is wrong
+                continue
+
+            # Find out how many instances the device has
+            rsp = yield QueryNumberOfInstances(device=addr)
+            if check_bad_rsp(rsp):
+                continue
+            num_inst = rsp.value
+
+            # For each instance, check it is enabled and then query the type
+            for inst_int in range(num_inst):
+                inst = InstanceNumber(inst_int)
+                rsp = yield QueryInstanceEnabled(device=addr, instance=inst)
+                if check_bad_rsp(rsp):
+                    continue
+                if not rsp.value:
+                    # Skip if not enabled
+                    continue
+                rsp = yield QueryInstanceType(device=addr, instance=inst)
+                if check_bad_rsp(rsp):
+                    continue
+
+                yield seq_progress(
+                    message=f"A²{addr_int} I{inst_int} type: {rsp.value}"
+                )
+
+                # Add the type to the device/instance map
+                self.add_type(
+                    short_address=addr,
+                    instance_number=inst,
+                    instance_type=rsp.value,
+                )
+
+    def add_type(
+        self,
+        *,
+        short_address: DeviceShort | int,
+        instance_number: InstanceNumber | int,
+        instance_type: types.ModuleType | int,
+    ) -> None:
+        """
+        Adds a mapping from device address and instance number to instance
+        type, so that the "Device/Instance" addressing scheme can be used for
+        event messages. Using this method will enable Device/Instance
+        messages to be decoded properly, instead of returning the default
+        `AmbiguousInstanceType` The * barrier means that arguments must be
+        named, this is to avoid accidental ambiguity.
+
+        :param short_address: Integer or `DeviceShort` of the relevant address
+        :param instance_number: Integer or `InstanceNumber` of the relevant
+        instance number
+        :param instance_type: Either an integer corresponding to the instance
+        type, e.g. 1 for "Part 301", or the module name that implements the type
+         e.g. "device.pushbutton" (which internally has a property
+         `instance_type`)
+        :return: None
+        """
+        if isinstance(short_address, DeviceShort):
+            short_address = short_address.address
+        if isinstance(instance_number, InstanceNumber):
+            instance_number = instance_number.value
+        if hasattr(instance_type, "instance_type"):
+            instance_type = int(instance_type.instance_type)
+        else:
+            instance_type = int(instance_type)
+        self._mapping[(short_address, instance_number)] = instance_type
+
+    def get_type(
+        self,
+        *,
+        short_address: DeviceShort | int,
+        instance_number: InstanceNumber | int,
+    ) -> Optional[int]:
+        """
+        Looks up the instance type based on the short address and instance
+        number. Only works if this has previously been added through a call
+        to `add_type()`. The * barrier means that arguments must be named,
+        this is to avoid accidental ambiguity.
+
+        :param short_address: Integer or `DeviceShort` of the relevant address
+        :param instance_number: Integer or `InstanceNumber` of the relevant
+        instance number
+        :return: Either the instance type as an integer, or None
+        """
+        if isinstance(short_address, DeviceShort):
+            short_address = short_address.address
+        if isinstance(instance_number, InstanceNumber):
+            instance_number = instance_number.value
+        return self._mapping.get((short_address, instance_number), None)
+
+    def clear(self) -> None:
+        """
+        Unconditionally clears all mappings
+
+        :return: None
+        """
+        self._mapping = {}
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self._mapping})"

--- a/dali/device/pushbutton.py
+++ b/dali/device/pushbutton.py
@@ -1,0 +1,325 @@
+"""
+Commands, responses and events from IEC 62386 part 301: "Input devices —
+Push buttons"
+"""
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from dali import command
+from dali.device import general
+
+# "1" corresponds with "Part 301", as per Table 4 of IEC 62386 part 103
+instance_type = 1
+
+
+class _PushbuttonEvent(general._Event):
+    """
+    Encodes and decodes messages defined in IEC 62386 part 301. For Push
+    Buttons, the event information uniquely defines an event, i.e. there is
+    no additional data encoded in the event information apart from the event
+    name itself.
+    """
+
+    # "1" corresponds with "Part 301", as per Table 4 of IEC 62386 part 103
+    _instance_type = instance_type
+    _event_classes: Dict[int, Type[_PushbuttonEvent]] = {}
+
+    @classmethod
+    def _register_subclass(cls, subclass):
+        if not issubclass(subclass, _PushbuttonEvent):
+            raise RuntimeError(
+                "Somehow called _PushbuttonEvent._register_subclass() "
+                "without a subclass of _PushbuttonEvent"
+            )
+        cls._event_classes[subclass._event_info] = subclass
+
+    @classmethod
+    def from_event_data(cls, event_data: int):
+        return cls._event_classes.get(event_data)
+
+
+###############################################################################
+# Event Filters from Part 301 Table 3 start here
+###############################################################################
+
+
+class InstanceEventFilter(general.InstanceEventFilter):
+    """
+    Event Filters for a push button instance, as defined in Part 301 Table 3
+    """
+
+    button_released = 0b00000001
+    button_pressed = 0b00000010
+    short_press = 0b00000100
+    double_press = 0b00001000
+    long_press_start = 0b00010000
+    long_press_repeat = 0b00100000
+    long_press_stop = 0b01000000
+    button_stuck_free = 0b10000000
+
+
+###############################################################################
+# Commands from Part 301 Table 2 start here
+###############################################################################
+
+
+class ButtonReleased(_PushbuttonEvent):
+    """
+    The button is released
+    """
+
+    enabled_by = InstanceEventFilter.button_released
+    _event_info = 0b0000000000
+
+
+class ButtonPressed(_PushbuttonEvent):
+    """
+    The button is pressed
+    """
+
+    enabled_by = InstanceEventFilter.button_pressed
+    _event_info = 0b0000000001
+
+
+class ShortPress(_PushbuttonEvent):
+    """
+    The button is pressed and released, without being pressed quickly again (
+    in case double press is enabled), or the button is pressed and quickly
+    released (in case double press is disabled).
+
+    The Short Timer differentiates a short press from a long press. If a
+    button is released within T_short, either a short or a double press event
+    will follow; otherwise the press will generate a long press event.
+
+    See also: SetShortTimer
+    """
+
+    enabled_by = InstanceEventFilter.short_press
+    _event_info = 0b0000000010
+
+
+class DoublePress(_PushbuttonEvent):
+    """
+    The button is pressed and released, quickly followed by another press.
+
+    The Double Timer (T_double) differentiates a single short press from a
+    double press. If a button is pressed, released, then pressed again within
+    T_double then a double press event is generated. T_double is disabled by
+    setting a value of 0, when disabled a short press event is generated
+    immediately upon button release.
+
+    See also: SetDoubleTimer
+    """
+
+    enabled_by = InstanceEventFilter.double_press
+    _event_info = 0b0000000101
+
+
+class LongPressStart(_PushbuttonEvent):
+    """
+    The button is pressed without releasing it.
+
+    The Short Timer (T_short) differentiates a short press from a long press.
+    If a button is released within T_short, either a short or a double press
+    event will follow; otherwise the press will generate a long press event.
+
+    See also: SetShortTimer
+    """
+
+    enabled_by = InstanceEventFilter.long_press_start
+    _event_info = 0b0000001001
+
+
+class LongPressRepeat(_PushbuttonEvent):
+    """
+    Following a long press start condition, the button is still pressed. The
+    event occurs at regular intervals as long as the condition holds.
+
+    The Repeat Timer (T_repeat) sets the repetition interval of long press
+    repeat events.
+
+    See also: SetRepeatTimer
+    """
+
+    enabled_by = InstanceEventFilter.long_press_repeat
+    _event_info = 0b0000001011
+
+
+class LongPressStop(_PushbuttonEvent):
+    """
+    Following a long press start condition, the button is released. If the long
+    press stop event is enabled, there is no separate button released event.
+    """
+
+    enabled_by = InstanceEventFilter.long_press_stop
+    _event_info = 0b0000001100
+
+
+class ButtonFree(_PushbuttonEvent):
+    """
+    The button has been stuck and is now released
+    """
+
+    enabled_by = InstanceEventFilter.button_stuck_free
+    _event_info = 0b0000001110
+
+
+class ButtonStuck(_PushbuttonEvent):
+    """
+    The button has been pressed for a very long time and is assumed stuck.
+
+    If a button is pressed or bouncing longer than the Stuck Timer (T_stuck)
+    it is considered broken.
+
+    See also: SetStuckTimer
+    """
+
+    enabled_by = InstanceEventFilter.button_stuck_free
+    _event_info = 0b0000001111
+
+
+###############################################################################
+# Commands from Part 301 Table 10 start here
+###############################################################################
+
+
+class _PushbuttonCommand(general._StandardInstanceCommand):
+    """
+    An extension of the standard commands, addressed to a push button control
+    device instance
+    """
+
+    _opcode = None
+
+
+class SetShortTimer(_PushbuttonCommand):
+    """
+    The Short Timer (T_short) differentiates a short press from a long press.
+    If a button is released within T_short, either a short or a double press
+    event will follow; otherwise the press will generate a long press event.
+
+    T_short increments in intervals of 20 ms, i.e. the raw value needs to be
+    multiplied by 20 ms to get the actual value.
+    """
+
+    inputdev = True
+    uses_dtr0 = True
+    sendtwice = True
+    _opcode = 0x00
+
+
+class SetDoubleTimer(_PushbuttonCommand):
+    """
+    The Double Timer (T_double) differentiates a single short press from a
+    double press. If a button is pressed, released, then pressed again within
+    T_double then a double press event is generated. T_double is disabled by
+    setting a value of 0, when disabled a short press event is generated
+    immediately upon button release.
+
+    T_double increments in intervals of 20 ms, i.e. the raw value needs to be
+    multiplied by 20 ms to get the actual value.
+    """
+
+    inputdev = True
+    uses_dtr0 = True
+    sendtwice = True
+    _opcode = 0x01
+
+
+class SetRepeatTimer(_PushbuttonCommand):
+    """
+    The Repeat Timer (T_repeat) sets the repetition interval of long press
+    repeat events.
+
+    T_repeat increments in intervals of 20 ms, i.e. the raw value needs to be
+    multiplied by 20 ms to get the actual value.
+    """
+
+    inputdev = True
+    uses_dtr0 = True
+    sendtwice = True
+    _opcode = 0x02
+
+
+class SetStuckTimer(_PushbuttonCommand):
+    """
+    If a button is pressed or bouncing longer than the Stuck Timer (T_stuck)
+    it is considered broken.
+
+    T_stuck increments in intervals of 1 second, i.e. the raw value is the
+    actual value, in seconds.
+    """
+
+    inputdev = True
+    uses_dtr0 = True
+    sendtwice = True
+    _opcode = 0x03
+
+
+class QueryShortTimer(_PushbuttonCommand):
+    """
+    Gets the current value for T_short.
+
+    See also: SetShortTimer
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0A
+
+
+class QueryShortTimerMin(_PushbuttonCommand):
+    """
+    Gets the minimum value for T_short supported by the hardware
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0B
+
+
+class QueryDoubleTimer(_PushbuttonCommand):
+    """
+    Gets the current value for T_double.
+
+    See also: SetDoubleTimer
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0C
+
+
+class QueryDoubleTimerMin(_PushbuttonCommand):
+    """
+    Gets the minimum value for T_double supported by the hardware.
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0D
+
+
+class QueryRepeatTimer(_PushbuttonCommand):
+    """
+    Gets the current value for T_repeat.
+
+    See also: SetRepeatTimer
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0E
+
+
+class QueryStuckTimer(_PushbuttonCommand):
+    """
+    Gets the current value for T_stuck.
+
+    See also: SetStuckTimer
+    """
+
+    inputdev = True
+    response = command.NumericResponse
+    _opcode = 0x0F

--- a/dali/device/sequences.py
+++ b/dali/device/sequences.py
@@ -1,0 +1,223 @@
+"""
+Sequence for simplifying certain interactions with 24-bit DALI devices
+"""
+from __future__ import annotations
+
+import types
+from typing import Generator, Optional, Type
+
+from dali.address import DeviceShort, InstanceNumber
+from dali.command import Command, Response
+from dali.device.general import (
+    DTR0,
+    DTR1,
+    DTR2,
+    EventScheme,
+    InstanceEventFilter,
+    QueryEventFilterH,
+    QueryEventFilterL,
+    QueryEventFilterM,
+    QueryEventScheme,
+    QueryEventSchemeResponse,
+    SetEventFilter,
+    SetEventScheme,
+)
+from dali.device.helpers import check_bad_rsp
+
+
+def SetEventSchemes(
+    device: DeviceShort,
+    instance: InstanceNumber,
+    scheme: EventScheme,
+) -> Generator[
+    Command,
+    Optional[Response],
+    Optional[QueryEventSchemeResponse],
+]:
+    """
+    A generator sequence to set the event scheme of a device instance. Use
+    with an appropriate DALI driver instance, through the `run_sequence()`
+    method.
+
+    Returns the event scheme that the target instance actually set.
+
+    Example:
+    ```
+    await driver.run_sequence(
+        SetEventSchemes(
+            device=address.DeviceShort(1),
+            instance=address.InstanceNumber(2),
+            scheme=EventScheme.device_instance,
+        )
+    )
+    ```
+    """
+    # Although the proper types are expected, ints are common enough for
+    # addresses and their meaning is unambiguous in this context
+    if isinstance(device, int):
+        device = DeviceShort(device)
+    if isinstance(instance, int):
+        instance = InstanceNumber(instance)
+
+    # The scheme should be a member of EventScheme, but an int does work just
+    # fine, so allow it
+    pos = int(scheme)
+    # Check that 'scheme' is actually an EventScheme member, will raise a
+    # ValueError if not
+    EventScheme(pos)
+
+    rsp = yield DTR0(pos)
+    if rsp is not None:
+        return
+
+    rsp = yield SetEventScheme(device=device, instance=instance)
+    if rsp is not None:
+        return
+
+    rsp = yield QueryEventScheme(device=device, instance=instance)
+    return rsp
+
+
+def SetEventFilters(
+    device: DeviceShort,
+    instance: InstanceNumber,
+    filter_value: InstanceEventFilter,
+) -> Generator[Command, Optional[Response], Optional[InstanceEventFilter]]:
+    """
+    A generator sequence to set the event filters of a device instance.
+    Use with an appropriate DALI driver instance, through the `run_sequence()`
+    method.
+
+    Returns the event filters that the target device actually set.
+
+    Example:
+    ```
+    from dali import address
+    from dali.device.pushbutton import InstanceEventFilter as filter_pb
+
+    await driver.run_sequence(
+        SetEventFilters(
+            device=address.DeviceShort(1),
+            instance=address.InstanceNumber(2),
+            filter_value=filter_pb.short_press | filter_pb.double_press,
+        )
+    )
+    ```
+    """
+    if not isinstance(filter_value, int):
+        raise TypeError(
+            f"'filter_value' must be an int, not {type(filter_value)}"
+        )
+    # Although the proper types are expected, ints are common enough for
+    # addresses and their meaning is unambiguous in this context
+    if isinstance(device, int):
+        device = DeviceShort(device)
+    if isinstance(instance, int):
+        instance = InstanceNumber(instance)
+
+    uses_dtr1 = filter_value.dali_width() > 8
+    uses_dtr2 = filter_value.dali_width() > 16
+
+    # The values in InstanceEventFilter are already mapped out to the
+    # corresponding bits, through the inheritance from IntFlag
+    lo, md, hi = filter_value.to_bytes(3, "little")
+
+    # Set the various values into the DTRs
+    rsp = yield DTR0(lo)
+    if rsp is not None:
+        return
+    if uses_dtr1:
+        rsp = yield DTR1(md)
+        if rsp is not None:
+            return
+    if uses_dtr2 > 16:
+        rsp = yield DTR2(hi)
+        if rsp is not None:
+            return
+    # Set the filters
+    rsp = yield SetEventFilter(device=device, instance=instance)
+    if rsp is not None:
+        return
+
+    # Read back the values that were set
+    rsp = yield QueryEventFilterL(device=device, instance=instance)
+    if check_bad_rsp(rsp):
+        return
+    lo = rsp.value
+    if uses_dtr1:
+        rsp = yield QueryEventFilterM(device=device, instance=instance)
+        if check_bad_rsp(rsp):
+            return
+        md = rsp.value
+    if uses_dtr2:
+        rsp = yield QueryEventFilterH(device=device, instance=instance)
+        if check_bad_rsp(rsp):
+            return
+        hi = rsp.value
+
+    return filter_value.__class__(int.from_bytes((lo, md, hi), "little"))
+
+
+def QueryEventFilters(
+    device: DeviceShort,
+    instance: InstanceNumber,
+    filter_type: types.ModuleType | Type[InstanceEventFilter],
+) -> Generator[Command, Optional[Response], Optional[InstanceEventFilter]]:
+    """
+    A generator sequence to query the event filters of a device instance.
+    Use with an appropriate DALI driver instance, through the `run_sequence()`
+    method.
+
+    Returns the event filters used by the target device.
+
+    :param device: A DeviceShort address to target
+    :param instance: An InstanceNumber to target
+    :param filter_type: Either the module of the type being targeted, or a
+    specific InstanceEventFilter type to use, e.g. `dali.device.pushbutton`
+    :return: A generator function, to use with e.g. `driver.run_sequence()`
+
+    Example:
+    ```
+    from dali import address
+    from dali.device import pushbutton
+
+    await driver.run_sequence(
+        QueryEventFilters(
+            device=address.DeviceShort(1),
+            instance=address.InstanceNumber(2),
+            filter_type=pushbutton,
+        )
+    )
+    ```
+    """
+    if hasattr(filter_type, "InstanceEventFilter"):
+        filter_type = getattr(filter_type, "InstanceEventFilter")
+    elif not issubclass(filter_type, InstanceEventFilter):
+        raise TypeError("'filter_type' must be an InstanceEventFilter subclass")
+    # Although the proper types are expected, ints are common enough for
+    # addresses and their meaning is unambiguous in this context
+    if isinstance(device, int):
+        device = DeviceShort(device)
+    if isinstance(instance, int):
+        instance = InstanceNumber(instance)
+
+    lo = 0
+    md = 0
+    hi = 0
+
+    rsp = yield QueryEventFilterL(device=device, instance=instance)
+    if check_bad_rsp(rsp):
+        return
+    lo = rsp.value
+    if filter_type.dali_width() > 8:
+        rsp = yield QueryEventFilterM(device=device, instance=instance)
+        if check_bad_rsp(rsp):
+            return
+        md = rsp.value
+    if filter_type.dali_width() > 16:
+        rsp = yield QueryEventFilterH(device=device, instance=instance)
+        if check_bad_rsp(rsp):
+            return
+        hi = rsp.value
+
+    return filter_type(int.from_bytes((lo, md, hi), "little"))

--- a/dali/tests/fakes_serial.py
+++ b/dali/tests/fakes_serial.py
@@ -1,39 +1,42 @@
 """
-fakes_serial.py - A mock implementation of a serial driver, for testing without relying on hardware
+fakes_serial.py - A mock implementation of a serial driver, for testing without
+relying on hardware
 
 
 This file is part of python-dali.
 
-python-dali is free software: you can redistribute it and/or modify it under the terms of the GNU
-Lesser General Public License as published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+python-dali is free software: you can redistribute it and/or modify it under the
+terms of the GNU Lesser General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-Lesser General Public License for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU Lesser General Public License along with this program.
-If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>.
 
 
 
-DriverSerialDummy provides a basic mock DALI bus, with fake devices connected to it. These fake
-devices can respond to a limited subset of DALI commands - useful in testing logic of other parts
-of the library.
+DriverSerialDummy provides a basic mock DALI bus, with fake devices connected to
+it. These fake devices can respond to a limited subset of DALI commands - useful
+in testing logic of other parts of the library.
 
-DriverSerialDummy instances are created using a path to a file, rather than a real serial device.
-This file is used to log all of the DALI commands which would be sent out over the DALI bus if
-using a "real" driver. During tests, the log file can be read to verify the expected command was
-sent.
+DriverSerialDummy instances are created using a path to a file, rather than a
+real serial device. This file is used to log all of the DALI commands which
+would be sent out over the DALI bus if using a "real" driver. During tests, the
+log file can be read to verify the expected command was sent.
 
-Three types of devices are emulated, DT6 LEDs, DT7 relays, and the Lunatone OEM-specific "Jalousie"
-relay (used for controlling blinds). The number of each dummy device to create is specified in a
-query string, after the path to the logfile, using the keys 'led', 'relay', and 'cover'.
+Three types of devices are emulated, DT6 LEDs, DT7 relays, and the Lunatone
+OEM-specific "Jalousie" relay (used for controlling blinds). The number of each
+dummy device to create is specified in a query string, after the path to the
+logfile, using the keys 'led', 'relay', and 'cover'.
 
 Example:
 ```
-dummy_driver = DriverSerialDummy(uri="dummy:/tmp/dali0.txt?led=2&cover=2&relay=4")
-await dummy_driver.connect()
+dummy = DriverSerialDummy(uri="dummy:/tmp/dali0.txt?led=2&cover=2&relay=4")
+await dummy.connect()
 ```
 """
 from __future__ import annotations
@@ -41,14 +44,15 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional
 from urllib.parse import ParseResult, parse_qs
 
 from dali import command, gear, memory
-from dali.driver.serial import DriverSerialBase
+from dali.device.helpers import DeviceInstanceTypeMapper
+from dali.driver import trace_logging  # noqa: F401
+from dali.driver.serial import DistributorQueue, DriverSerialBase
 from dali.memory.location import MemoryBank
 from dali.tests import fakes as dali_fakes
-from dali.driver import trace_logging  # noqa: F401
 
 _LOG = logging.getLogger("dali.driver")
 
@@ -158,19 +162,25 @@ class DriverSerialDummy(DriverSerialBase):
             None,
         ]
 
-    def __init__(self, *, uri: Union[str, ParseResult]):
+    def __init__(
+        self,
+        uri: str | ParseResult,
+        dev_inst_map: Optional[DeviceInstanceTypeMapper] = None,
+    ):
         """
-        The DriverSerialDummy class will 'magically' create pretend devices, based on the query
-        string passed in through the URI. These dummy devices won't physically exist, but do
-        provide a way of testing higher-level functions without needing physical hardware. Any
-        interactions that would be sent to hardware are instead written to a logfile, created
-        locally at the path provided in the URI.
+        The DriverSerialDummy class will 'magically' create pretend devices,
+        based on the query string passed in through the URI. These dummy devices
+        won't physically exist, but do provide a way of testing higher-level
+        functions without needing physical hardware. Any interactions that would
+        be sent to hardware are instead written to a logfile, created locally at
+        the path provided in the URI.
 
-        :param uri: A special URI (either string or ParseResult object) which tells the dummy
-        driver where to save its logfile, and how many dummy devices to create.
+        :param uri: A special URI (either string or ParseResult object) which
+        tells the dummy driver where to save its logfile, and how many dummy
+        devices to create.
         URI format example: "dummy:///path/to/logfile?led=4&cover=2&relay=2"
         """
-        super().__init__(uri)
+        super().__init__(uri=uri, dev_inst_map=dev_inst_map)
         uri = self.uri
 
         self._log_path = uri.path
@@ -192,57 +202,61 @@ class DriverSerialDummy(DriverSerialBase):
         except (IndexError, KeyError):
             _LOG.info(f"URI query does not specify any Relays: '{uri.query}'")
 
-        _LOG.debug(f"Initialising dummy driver with logfile path '{self._log_path}'")
+        _LOG.debug(
+            f"Initialising dummy driver with logfile path '{self._log_path}'"
+        )
         _LOG.info(
-            f"Dummy instances to be created: {self._num_leds} LEDs, {self._num_covers} covers, "
-            f"{self._num_relays} relays"
+            f"Dummy instances to be created: {self._num_leds} LEDs, "
+            f"{self._num_covers} covers, {self._num_relays} relays"
         )
 
         # Create dummy 'devices'. All are addressed sequentially.
         self._dummy_bus = dali_fakes.Bus([])
-        new_address = 0
+        new_ad = 0
         for _ in range(self._num_leds):
             self._dummy_bus.gear.append(
                 dali_fakes.Gear(
-                    new_address,
+                    new_ad,
                     devicetypes=[6],
                     memory_banks=(DriverSerialDummy.DummyBank0,),
                 )
             )
             # Force the LSB of the device serial number to equal the address
-            self._dummy_bus.gear[new_address].memory_banks[0].contents[18] = new_address
-            new_address += 1
+            self._dummy_bus.gear[new_ad].memory_banks[0].contents[18] = new_ad
+            new_ad += 1
         for _ in range(self._num_covers):
             new_cover = dali_fakes.Gear(
-                new_address,
+                new_ad,
                 devicetypes=[0],
                 memory_banks=(
                     DriverSerialDummy.DummyJalousieBank0,
                     DriverSerialDummy.DummyJalousieBank2,
                 ),
             )
-            # Emulating a Lunatone Jalousie, which uses scenes to control movement up/down
+            # Emulating a Lunatone Jalousie, which uses scenes to control
+            # movement up/down
             new_cover.scenes[1] = 254
             new_cover.scenes[3] = 253
-            # The serial number has a different address for DALI-1 (0x0E instead of 0x12)
-            new_cover.memory_banks[0].contents[0x0E] = new_address
+            # The serial number has a different address for DALI-1 (0x0E
+            # instead of 0x12)
+            new_cover.memory_banks[0].contents[0x0E] = new_ad
             self._dummy_bus.gear.append(new_cover)
-            # Keep track of which addresses belong to covers, for special handling
-            self._cover_addrs.add(new_address)
-            new_address += 1
+            # Keep track of addresses belonging to covers, for special handling
+            self._cover_addrs.add(new_ad)
+            new_ad += 1
         for _ in range(self._num_relays):
             self._dummy_bus.gear.append(
                 dali_fakes.Gear(
-                    new_address,
+                    new_ad,
                     devicetypes=[7],
                     memory_banks=(DriverSerialDummy.DummyBank0,),
                 )
             )
             # Force the LSB of the device serial number to equal the address
-            self._dummy_bus.gear[new_address].memory_banks[0].contents[18] = new_address
-            new_address += 1
+            self._dummy_bus.gear[new_ad].memory_banks[0].contents[18] = new_ad
+            new_ad += 1
 
-        if new_address >= 64:
+        if new_ad >= 64:
             raise RuntimeError("Cannot have more than 64 devices on a DALI bus")
 
     @staticmethod
@@ -253,58 +267,74 @@ class DriverSerialDummy(DriverSerialBase):
         _LOG.info(f"Turning off A{addr}")
         self._dummy_bus.gear[addr].level = 0
 
-    async def connect(self) -> None:
+    async def connect(self, *, scan_dev_inst: bool = False) -> None:
         if self.is_connected:
-            _LOG.warning("'connect()' called but dummy driver already connected")
+            _LOG.warning(
+                "'connect()' called but dummy driver already connected"
+            )
             return
-        # The dummy driver doesn't actually do any real communication, all we need to do is check
-        # that the path we've been given can be opened
+        # The dummy driver doesn't actually do any real communication, all we
+        # need to do is check that the path we've been given can be opened
         with open(self._log_path, mode="wt", encoding="utf-8") as log_file:
             log_file.write(
                 f"\n{self._get_date()} Starting new DriverSerialDummy instance\n"
             )
-        # The file will be automatically closed after the write is done, it's not quite as efficient
-        # as it could be to open it each time, but it's a bit safer and ensures a clean write
+        # The file will be automatically closed after the write is done, it's
+        # not quite as efficient as it could be to open it each time, but it's
+        # a bit safer and ensures a clean write
+
         self._connected.set()
+
+        # Scan the bus for control devices, and create a mapping of addresses
+        # to instance types
+        if scan_dev_inst:
+            _LOG.info("Scanning DALI bus for control devices")
+            await self.run_sequence(self.dev_inst_map.autodiscover())
+            _LOG.info(f"Found {len(self.dev_inst_map.mapping)} instances")
 
     async def send(
         self, msg: command.Command, in_transaction: bool = False
     ) -> Optional[command.Response]:
         """
-        The 'send()' method for the DriverSerialDummy class doesn't actually communicate with
-        anything external - it just tries to imitate hardware, at a very basic level. For now,
-        all that is implemented is:
-        * Short addressing (i.e. referring to a dummy device directly by its address)
+        The 'send()' method for the DriverSerialDummy class doesn't actually
+        communicate with anything external - it just tries to imitate hardware,
+        at a very basic level. For now, all that is implemented is:
+        * Short addressing (i.e. referring to a dummy directly by its address)
         * Broadcast addressing
-        * Brightness/Power Level (can be set via DAPC, RecallMaxLevel, RecallMinLevel, Off)
+        * Brightness/Power Level (DAPC, RecallMaxLevel, RecallMinLevel, Off)
         * Device Type
 
         :param msg: The DALI message to send
-        :param in_transaction: Flag whether or not this 'send()' call is part of a transaction
-        (i.e. if this call is coming from the 'run_sequence()' method). If the flag is set then
-        the lock will not be acquired before sending.
-        :return: If a command being sent expects a response, and the type is supported by
-        DriverSerialDummy, then it will be returned by the 'send()' call. If more than one command
-        generates a response then only the last response will be returned. Otherwise, None.
+        :param in_transaction: Flag whether or not this 'send()' call is part
+        of a transaction (i.e. if this call is coming from the 'run_sequence()'
+        method). If the flag is set then the lock will not be acquired before
+        sending.
+        :return: If a command being sent expects a response, and the type is
+        supported by DriverSerialDummy, then it will be returned by the 'send()'
+        call. If more than one command generates a response then only the last
+        response will be returned. Otherwise, None.
         """
         # Only send if the driver is connected
         if not self.is_connected:
             _LOG.critical(f"Cannot send, driver is not connected: {self}")
             raise IOError("Cannot send, driver is not connected")
 
-        # If multiple responses are requested in a list of messages to send, only the last response
-        # will be returned
+        # If multiple responses are requested in a list of messages to send,
+        # only the last response will be returned
         response = None
 
-        # "Send" each message, one at a time, and figure out what the dummy response should be
+        # "Send" each message, one at a time, and figure out what the dummy
+        # response should be
         if not in_transaction:
             await self.transaction_lock.acquire()
         try:
             with open(self._log_path, mode="at", encoding="utf-8") as log_file:
-                # Write the message to the log file, emulating sending it over a DALI bus
+                # Write the message to the log file, emulating sending it over
+                # a DALI bus
                 log_file.write(f"{self._get_date()} {msg}\n")
-                # Because writing to a log file is much faster than writing over RS232, there
-                # is a short delay here to make the dummy act a bit more like a real DALI device
+                # Because writing to a log file is much faster than writing
+                # over RS232, there is a short delay here to make the dummy act
+                # a bit more like a real DALI device
                 await asyncio.sleep(DriverSerialDummy.hardware_delay)
                 # Get the response from the dummy bus
                 response = self._dummy_bus.send(msg)
@@ -315,10 +345,14 @@ class DriverSerialDummy(DriverSerialBase):
                         if isinstance(msg, gear.general.GoToScene):
                             dst = msg.destination.address
                             if dst in self._cover_addrs:
-                                _LOG.info(f"Scheduling dummy call to turn off A{dst}")
+                                _LOG.info(
+                                    f"Scheduling dummy call to turn off A{dst}"
+                                )
                                 asyncio.get_running_loop().call_later(
                                     delay=10.0,
-                                    callback=lambda: self._set_level_off(addr=dst),
+                                    callback=lambda: self._set_level_off(
+                                        addr=dst
+                                    ),
                                 )
 
         finally:
@@ -327,5 +361,9 @@ class DriverSerialDummy(DriverSerialBase):
 
         return response
 
-    async def wait_dali_rx(self) -> command.Command:
-        raise RuntimeError("'wait_dali_rx()' is not implemented for DriverSerialDummy")
+    def new_dali_rx_queue(self) -> DistributorQueue:
+        _LOG.warning(
+            "'new_dali_rx_queue()' called on DriverSerialDummy, beware this "
+            "will always be empty!"
+        )
+        return DistributorQueue()

--- a/dali/tests/test_command.py
+++ b/dali/tests/test_command.py
@@ -2,7 +2,6 @@ import unittest
 from dali import address
 from dali import command
 from dali import frame
-# from dali.device import general as generaldevice
 from dali.gear import general as generalgear
 
 
@@ -27,6 +26,12 @@ def _test_pattern():
         yield 24, (0xc1, c, 0x00), 0
     for c in (0xc5, 0xc7, 0xc9):
         yield 24, (c, 0x00, 0x00), 0
+    # Control devices, event messages for push buttons (part 301)
+    for e in (0, 1, 2, 5, 9, 11, 12, 14, 15):
+        yield 24, (0xc2, 0x04, e), 0
+    # Control devices, QueryEventFilter
+    for o in (0x90, 0x91, 0x92):
+        yield 24, (0x03, 0x00, o), 0
 
 
 class TestCommands(unittest.TestCase):
@@ -44,6 +49,9 @@ class TestCommands(unittest.TestCase):
                 frame.ForwardFrame(fs, d), devicetype=dt)
             seen[c.__class__] = True
         for cls in command.Command._commands:
+            if cls.__name__ == "UnknownEvent":
+                # UnknownEvent shouldn't come up, so don't expect to see it
+                continue
             self.assertTrue(
                 cls in seen,
                 'class {} not covered by tests'.format(cls.__name__)

--- a/dali/tests/test_device_sequences.py
+++ b/dali/tests/test_device_sequences.py
@@ -1,0 +1,253 @@
+import pytest
+
+from dali.address import DeviceShort, InstanceNumber
+from dali.command import NumericResponse, YesNoResponse
+from dali.device import pushbutton
+from dali.device.general import (
+    DTR0,
+    EventScheme,
+    QueryDeviceStatus,
+    QueryDeviceStatusResponse,
+    QueryEventFilterZeroToSeven,
+    QueryEventScheme,
+    QueryEventSchemeResponse,
+    SetEventFilter,
+)
+from dali.device.helpers import DeviceInstanceTypeMapper, check_bad_rsp
+from dali.device.pushbutton import InstanceEventFilter as EventFilter_pb
+from dali.device.sequences import (
+    QueryEventFilters,
+    SetEventFilters,
+    SetEventSchemes,
+)
+from dali.frame import BackwardFrame, BackwardFrameError
+from dali.tests import fakes
+
+
+def test_check_bad_rsp_none():
+    # A 'None' is always a bad response
+    assert check_bad_rsp(None)
+
+
+def test_check_bad_rsp_yes():
+    # A 'Yes' is always a good response
+    assert not check_bad_rsp(YesNoResponse(BackwardFrame(0xFF)))
+
+
+def test_check_bad_rsp_numeric():
+    # A numeric is always a good response, even if 0
+    assert not check_bad_rsp(NumericResponse(BackwardFrame(0xFF)))
+    assert not check_bad_rsp(NumericResponse(BackwardFrame(0x00)))
+
+
+def test_check_bad_rsp_missing():
+    # A numeric response expects a value
+    assert check_bad_rsp(NumericResponse(None))
+
+
+def test_check_bad_rsp_framing_error():
+    # A numeric response expects a value
+    assert check_bad_rsp(NumericResponse(BackwardFrameError(0xFF)))
+
+
+@pytest.fixture
+def fakes_bus():
+    return fakes.Bus(
+        [
+            fakes.Device(DeviceShort(0), memory_banks=(fakes.FakeBank0,)),
+            fakes.Device(DeviceShort(1), memory_banks=(fakes.FakeBank0,)),
+            fakes.Device(DeviceShort(2), memory_banks=(fakes.FakeBank0,)),
+        ]
+    )
+
+
+def test_device_autodiscover_good(fakes_bus):
+    dev_inst_map = DeviceInstanceTypeMapper()
+    fakes_bus.run_sequence(dev_inst_map.autodiscover())
+    # There are 4 instances on each fake device, and 3 devices, so 12 in total
+    assert len(dev_inst_map.mapping) == 12
+
+
+class DeviceFakeError(fakes.Device):
+    # Refer to Table 15 of Part 103, status bit 0 is "inputDeviceError"
+    _device_status = 0b00000001
+
+
+def test_device_autodiscover_skip_bad(fakes_bus):
+    dev_inst_map = DeviceInstanceTypeMapper()
+    # Add an extra fake device, one with an error bit set
+    fakes_bus.gear.append(
+        DeviceFakeError(DeviceShort(3), memory_banks=(fakes.FakeBank0,))
+    )
+
+    # The input device error bit should show up
+    rsp = fakes_bus.send(QueryDeviceStatus(DeviceShort(3)))
+    assert isinstance(rsp, QueryDeviceStatusResponse)
+    assert rsp.input_device_error
+
+    fakes_bus.run_sequence(dev_inst_map.autodiscover())
+    # The device in error mode shouldn't have had its instances counted
+    assert len(dev_inst_map.mapping) == 12
+
+
+class DeviceNoInstances(fakes.Device):
+    _instances = []
+
+
+def test_device_autodiscover_skip_no_instances(fakes_bus):
+    dev_inst_map = DeviceInstanceTypeMapper()
+    # Add an extra fake device, one with an error bit set
+    fakes_bus.gear.append(
+        DeviceNoInstances(DeviceShort(3), memory_banks=(fakes.FakeBank0,))
+    )
+
+    fakes_bus.run_sequence(dev_inst_map.autodiscover())
+    # One device has no instances to count
+    assert len(dev_inst_map.mapping) == 12
+
+
+def test_device_query_event_scheme(fakes_bus):
+    rsp = fakes_bus.send(QueryEventScheme(DeviceShort(1), InstanceNumber(1)))
+    assert isinstance(rsp, QueryEventSchemeResponse)
+    assert rsp.value == EventScheme.device_instance
+
+
+def test_device_set_event_schemes(fakes_bus):
+    rsp = fakes_bus.send(QueryEventScheme(DeviceShort(2), InstanceNumber(3)))
+    assert isinstance(rsp, QueryEventSchemeResponse)
+    assert rsp.value == EventScheme.device_instance
+
+    rsp = fakes_bus.run_sequence(
+        SetEventSchemes(DeviceShort(2), InstanceNumber(3), EventScheme.device)
+    )
+    assert isinstance(rsp, QueryEventSchemeResponse)
+    assert rsp.value == EventScheme.device
+
+
+def test_device_set_event_filters(fakes_bus):
+    rsp = fakes_bus.run_sequence(
+        QueryEventFilters(DeviceShort(1), InstanceNumber(2), pushbutton)
+    )
+    assert isinstance(rsp, EventFilter_pb)
+    assert rsp.value == 0
+
+    rsp = fakes_bus.run_sequence(
+        SetEventFilters(
+            DeviceShort(1),
+            InstanceNumber(2),
+            EventFilter_pb.short_press | EventFilter_pb.long_press_start,
+        )
+    )
+    assert isinstance(rsp, EventFilter_pb)
+    assert EventFilter_pb.short_press in rsp
+    assert EventFilter_pb.long_press_start in rsp
+    filter_rsp = rsp
+
+    rsp = fakes_bus.run_sequence(
+        QueryEventFilters(DeviceShort(1), InstanceNumber(2), EventFilter_pb)
+    )
+    assert isinstance(rsp, EventFilter_pb)
+    assert rsp == filter_rsp
+
+
+def test_event_filter_pushbutton_sequence_partial():
+    """
+    Confirms that the SetEventFilters sequence yields the expected
+    DALI message objects and sets the correct bit flags for DTR0 for
+    pushbutton instances
+    """
+    filter_to_set = (
+        EventFilter_pb.button_released
+        | EventFilter_pb.button_stuck_free
+        | EventFilter_pb.double_press
+    )
+    sequence = SetEventFilters(
+        device=DeviceShort(0),
+        instance=InstanceNumber(0),
+        filter_value=filter_to_set,
+    )
+    # The first message the sequence should send is DTR0
+    rsp = None
+    try:
+        cmd = sequence.send(rsp)
+    except StopIteration:
+        raise RuntimeError()
+    assert isinstance(cmd, DTR0)
+    assert cmd.frame.as_byte_sequence[2] == 0b10001001
+
+    # The second message should be SetEventFilter
+    try:
+        cmd = sequence.send(rsp)
+    except StopIteration:
+        raise RuntimeError()
+    assert isinstance(cmd, SetEventFilter)
+    assert cmd.destination == DeviceShort(0)
+    assert cmd.instance == InstanceNumber(0)
+
+    # The third message should be QueryEventFilterZeroToSeven
+    try:
+        cmd = sequence.send(rsp)
+    except StopIteration:
+        raise RuntimeError()
+    assert isinstance(cmd, QueryEventFilterZeroToSeven)
+
+    # The sequence should then just return whatever the response is
+    rsp = NumericResponse(BackwardFrame(0b10001001))
+    ret = None
+    try:
+        sequence.send(rsp)
+    except StopIteration as r:
+        ret = r.value
+    assert isinstance(ret, EventFilter_pb)
+    assert ret == filter_to_set
+    assert EventFilter_pb.button_released in ret
+    assert EventFilter_pb.button_stuck_free in ret
+    assert EventFilter_pb.double_press in ret
+    assert EventFilter_pb.short_press not in ret
+
+
+def test_event_filter_pushbutton_sequence_all():
+    filter_to_set = (
+        EventFilter_pb.double_press
+        | EventFilter_pb.long_press_start
+        | EventFilter_pb.button_pressed
+        | EventFilter_pb.short_press
+        | EventFilter_pb.long_press_repeat
+        | EventFilter_pb.button_released
+        | EventFilter_pb.long_press_stop
+        | EventFilter_pb.button_stuck_free
+        | EventFilter_pb.double_press  # Intentional duplicate
+    )
+    sequence = SetEventFilters(
+        device=DeviceShort(0),
+        instance=InstanceNumber(0),
+        filter_value=filter_to_set,
+    )
+    # The first message the sequence should send is DTR0
+    try:
+        cmd = sequence.send(None)
+    except StopIteration:
+        raise RuntimeError()
+    assert isinstance(cmd, DTR0)
+    assert cmd.frame.as_byte_sequence[2] == 0b11111111
+    # The previous test for the sequence adequately checks the remaining logic
+
+
+def test_event_filter_sequence_bad_type():
+    sequence = SetEventFilters(
+        device=DeviceShort(0),
+        instance=InstanceNumber(0),
+        filter_value="double_press",
+    )
+    # Using a string is not valid, it must be an enum object
+    with pytest.raises(TypeError):
+        sequence.send(None)
+
+    sequence = QueryEventFilters(
+        device=DeviceShort(0),
+        instance=InstanceNumber(0),
+        filter_type=EventFilter_pb.short_press,
+    )
+    # filter_type needs to be a type, not an instance
+    with pytest.raises(TypeError):
+        sequence.send(None)

--- a/dali/tests/test_dummy.py
+++ b/dali/tests/test_dummy.py
@@ -144,22 +144,22 @@ def test_dummy_init_no_relay(tmp_path):
 @pytest.mark.asyncio
 async def test_dummy_write_1(dummy_driver):
     await dummy_driver.driver.connect()
-    await dummy_driver.driver.send(gear.general.DAPC(address.Short(1), 254))
-    assert "ArcPower(<address 1>,254)" in dummy_driver.log.read()
+    await dummy_driver.driver.send(gear.general.DAPC(address.GearShort(1), 254))
+    assert "ArcPower(<address (control gear) 1>,254)" in dummy_driver.log.read()
 
 
 @pytest.mark.asyncio
 async def test_dummy_write_2(dummy_driver):
     await dummy_driver.driver.connect()
-    await dummy_driver.driver.send(gear.general.DAPC(address.Broadcast(), 127))
-    assert "ArcPower(<broadcast>,127)" in dummy_driver.log.read()
+    await dummy_driver.driver.send(gear.general.DAPC(address.GearBroadcast(), 127))
+    assert "ArcPower(<broadcast (control gear)>,127)" in dummy_driver.log.read()
 
 
 @pytest.mark.asyncio
 async def test_dummy_write_3(dummy_driver):
     await dummy_driver.driver.connect()
-    await dummy_driver.driver.send(gear.general.GoToScene(address.Short(1), 11))
-    assert "GoToScene(<address 1>,11)" in dummy_driver.log.read()
+    await dummy_driver.driver.send(gear.general.GoToScene(address.GearShort(1), 11))
+    assert "GoToScene(<address (control gear) 1>,11)" in dummy_driver.log.read()
 
 
 @pytest.mark.asyncio
@@ -167,7 +167,7 @@ async def test_dummy_sequence_device_types(dummy_driver):
     await dummy_driver.driver.connect()
     # The default of dummy_driver has 12 addressed control gears
     for ad in range(11):
-        short = address.Short(ad)
+        short = address.GearShort(ad)
         dev_types = await dummy_driver.driver.run_sequence(QueryDeviceTypes(short))
         # LEDs, DT6, are created first by the dummy driver
         if ad in range(0, 5):

--- a/dali/tests/test_events.py
+++ b/dali/tests/test_events.py
@@ -1,0 +1,266 @@
+from dataclasses import dataclass
+from typing import Optional, Type
+
+import pytest
+
+from dali.command import Command
+from dali.device import general, pushbutton
+from dali.device.general import (
+    AmbiguousInstanceType,
+    EventScheme,
+    InstanceEventFilter,
+    QueryEventSchemeResponse,
+    _Event,
+)
+from dali.device.helpers import DeviceInstanceTypeMapper
+from dali.device.pushbutton import InstanceEventFilter as EventFilter_pb
+from dali.frame import BackwardFrame, Frame
+
+
+def test_event_base_not_implemented():
+    with pytest.raises(NotImplementedError):
+        general._Event()
+
+
+@pytest.fixture
+def event_test_data_good():
+    @dataclass
+    class EventTestData:
+        event_type: Type[_Event] = pushbutton.ButtonReleased
+        short_address: Optional[int] = None
+        instance_number: Optional[int] = None
+        instance_group: Optional[int] = None
+        device_group: Optional[int] = None
+        frame: str = "000000000000000000000000"
+
+    test_data = (
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_group=2,
+            frame="110001000000010000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_group=31,
+            frame="111111100000010000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_group=0,
+            frame="110000000000010000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_number=2,
+            frame="100000101000100000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            instance_number=31,
+            frame="100000101111110000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ShortPress,
+            instance_group=31,
+            frame="111111100000010000000010",
+        ),
+        EventTestData(
+            event_type=pushbutton.DoublePress,
+            instance_group=31,
+            frame="111111100000010000000101",
+        ),
+        EventTestData(
+            event_type=pushbutton.LongPressStart,
+            device_group=15,
+            frame="100111100000010000001001",
+        ),
+        EventTestData(
+            event_type=pushbutton.LongPressRepeat,
+            device_group=15,
+            frame="100111100000010000001011",
+        ),
+        EventTestData(
+            event_type=pushbutton.LongPressStop,
+            device_group=16,
+            frame="101000000000010000001100",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonPressed,
+            instance_number=17,
+            frame="100000101100010000000001",
+        ),
+        EventTestData(
+            event_type=pushbutton.ButtonReleased,
+            short_address=0,
+            frame="000000000000010000000000",
+        ),
+        EventTestData(
+            event_type=pushbutton.ShortPress,
+            short_address=63,
+            frame="011111100000010000000010",
+        ),
+    )
+    return test_data
+
+
+def test_event_to_frame_good(event_test_data_good):
+    """
+    Tests a number of values against known-good expected frames, for various
+    pushbutton events
+    """
+    for test_case in event_test_data_good:
+        event = test_case.event_type(
+            short_address=test_case.short_address,
+            instance_number=test_case.instance_number,
+            instance_group=test_case.instance_group,
+            device_group=test_case.device_group,
+        )
+        event_frame = f"{event.frame.as_integer:024b}"
+        assert event_frame == test_case.frame
+
+
+def test_frame_to_event_good(event_test_data_good):
+    """
+    Tests a number of known-good frames, to ensure the correct object is
+    decoded
+    """
+    for test_case in event_test_data_good:
+        test_frame = Frame(24, data=int(test_case.frame, base=2))
+        event = Command.from_frame(test_frame)
+        assert isinstance(event, test_case.event_type)
+        if test_case.short_address:
+            assert event.short_address.address == test_case.short_address
+        assert event.instance_number == test_case.instance_number
+        assert event.instance_group == test_case.instance_group
+        assert event.device_group == test_case.device_group
+
+
+def test_event_pushbutton_repr_short_address():
+    event = pushbutton.ButtonReleased(short_address=1)
+    event_str = f"{event}"
+    assert "ButtonReleased(short_address=1)" == event_str
+
+
+def test_event_pushbutton_repr_instance_number():
+    event = pushbutton.ButtonReleased(instance_number=2)
+    event_str = f"{event}"
+    assert "ButtonReleased(instance_number=2)" == event_str
+
+
+def test_event_pushbutton_repr_instance_group():
+    event = pushbutton.ButtonReleased(instance_group=3)
+    event_str = f"{event}"
+    assert "ButtonReleased(instance_group=3)" == event_str
+
+
+def test_event_pushbutton_repr_device_group():
+    event = pushbutton.ButtonReleased(device_group=31)
+    event_str = f"{event}"
+    assert "ButtonReleased(device_group=31)" == event_str
+
+
+def test_frame_to_ambiguous_event():
+    dev_inst_frame = Frame(24, data=0b000000101000010000000010)
+    decode_cmd = Command.from_frame(dev_inst_frame)
+    assert isinstance(decode_cmd, general.AmbiguousInstanceType)
+    assert decode_cmd.short_address.address == 1
+    assert decode_cmd.instance_number == 1
+    assert decode_cmd.event_data == 0b0000000010
+
+
+def test_frame_to_event_dev_inst_pushbutton():
+    device_instance_map = DeviceInstanceTypeMapper()
+    device_instance_map.add_type(
+        short_address=1,
+        instance_number=1,
+        instance_type=pushbutton,
+    )
+
+    dev_inst_frame = Frame(24, data=0b000000101000010000000010)
+    decode_cmd = Command.from_frame(
+        dev_inst_frame, dev_inst_map=device_instance_map
+    )
+
+    assert isinstance(decode_cmd, pushbutton.ShortPress)
+    assert decode_cmd.short_address.address == 1
+    assert decode_cmd.instance_number == 1
+
+
+def test_event_decode_retry():
+    device_instance_map = DeviceInstanceTypeMapper()
+    device_instance_map.add_type(
+        short_address=1,
+        instance_number=1,
+        instance_type=pushbutton,
+    )
+
+    dev_inst_frame = Frame(24, data=0b000000101000010000000010)
+    decode_cmd = Command.from_frame(dev_inst_frame, dev_inst_map=None)
+
+    assert isinstance(decode_cmd, AmbiguousInstanceType)
+    assert decode_cmd.short_address.address == 1
+    assert decode_cmd.instance_number == 1
+    retry = decode_cmd.retry_decode(device_instance_map)
+    assert isinstance(retry, pushbutton.ShortPress)
+    assert retry.short_address.address == 1
+    assert retry.instance_number == 1
+
+
+def test_event_scheme_response_good():
+    rsp = QueryEventSchemeResponse(BackwardFrame(0))
+    assert rsp.value == EventScheme.instance
+
+    rsp = QueryEventSchemeResponse(BackwardFrame(1))
+    assert rsp.value == EventScheme.device
+
+    rsp = QueryEventSchemeResponse(BackwardFrame(2))
+    assert rsp.value == EventScheme.device_instance
+
+    rsp = QueryEventSchemeResponse(BackwardFrame(3))
+    assert rsp.value == EventScheme.device_group
+
+    rsp = QueryEventSchemeResponse(BackwardFrame(4))
+    assert rsp.value == EventScheme.instance_group
+
+
+def test_event_scheme_response_bad():
+    rsp = QueryEventSchemeResponse(BackwardFrame(5))
+    with pytest.raises(ValueError):
+        assert rsp.value
+
+
+def test_event_filter_subclasses():
+    """
+    Runs tests on all InstanceEventFilter subclasses to make sure they are
+    implemented properly, i.e. all members are powers of two, and all powers
+    of two are named up to the largest value
+    """
+    for subcls in InstanceEventFilter.__subclasses__():
+        # This would raise a TypeError if it is more than 24 bits
+        subcls.dali_width()
+
+        expected_values = {pow(2, n) for n in range(len(subcls))}
+        for member in subcls.__members__.values():
+            # Each member must only have a power of two value
+            if member.value not in expected_values:
+                raise KeyError(
+                    f"{subcls.__name__} from {subcls.__module__} enum value "
+                    f"'{member.value}' is not valid (must be sequential powers "
+                    "of two)"
+                )
+            expected_values.remove(member.value)
+        if len(expected_values) != 0:
+            raise ValueError(
+                f"{subcls.__name__} from {subcls.__module__} does not have "
+                f"values for the following flags: {expected_values}"
+            )
+
+
+def test_event_filter_pushbutton_width():
+    """
+    Confirms that the custom 'bit_width' property of the EventFilter_pb
+    enumerator works as expected, on both the class and on instances
+    """
+    assert EventFilter_pb.dali_width() == 8
+    filter_instance = EventFilter_pb(3)
+    assert filter_instance.dali_width() == 8

--- a/dali/tests/test_fakes.py
+++ b/dali/tests/test_fakes.py
@@ -1,157 +1,188 @@
 import unittest
 
 from dali.tests import fakes
-from dali import address
-from dali.gear import general
+from dali import address, gear, device
+from dali.address import DeviceShort, GearShort
 
 
 class TestFakeGear(unittest.TestCase):
+    def setUp(self):
+        """
+        Creates four fake control gears, with addresses 0 to 3. Also has a control
+        device, just there to make sure it stays silent.
+        """
+        self.bus = fakes.Bus(
+            [
+                fakes.Gear(GearShort(0), memory_banks=(fakes.FakeBank0,)),
+                fakes.Gear(GearShort(1), memory_banks=(fakes.FakeBank0,)),
+                fakes.Gear(GearShort(2), memory_banks=(fakes.FakeBank0,)),
+                fakes.Gear(GearShort(3), memory_banks=(fakes.FakeBank0,)),
+                fakes.Device(DeviceShort(0), memory_banks=(fakes.FakeBank0,)),
+            ]
+        )
+
+    def test_fake_gear_dapc(self):
+        # The level should initialise to 0
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 0)
+        self.bus.send(gear.general.DAPC(address.Short(0), 128))
+        # After DAPC the level should be 128
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 128)
+
+    def test_fake_gear_recall_max(self):
+        # The level should initialise to 0
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 0)
+        self.bus.send(gear.general.RecallMaxLevel(address.Short(0)))
+        # After RecallMaxLevel the level should be 254
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 254)
+
+    def test_fake_gear_recall_min(self):
+        # The level should initialise to 0
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        self.assertEqual(resp.value, 0)
+        self.bus.send(gear.general.RecallMinLevel(address.Short(1)))
+        # After RecallMaxLevel the level should be 1
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        self.assertEqual(resp.value, 1)
+
+    def test_fake_gear_set_min(self):
+        # Start with a level of 12
+        self.bus.send(gear.general.DAPC(address.Short(0), 12))
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 12)
+        # Set minimum level to 22
+        self.bus.send(gear.general.DTR0(22))
+        self.bus.send(gear.general.SetMinLevel(address.Short(0)))
+        # After SetMinLevel the level should be 22
+        resp = self.bus.send(gear.general.QueryMinLevel(address.Short(0)))
+        self.assertEqual(resp.value, 22)
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 22)
+        # Level should not go below 22
+        self.bus.send(gear.general.DAPC(address.Short(0), 12))
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 22)
+
+    def test_fake_gear_set_max(self):
+        # Start with a level of 228
+        self.bus.send(gear.general.DAPC(address.Short(1), 228))
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        self.assertEqual(resp.value, 228)
+        # Set maximum to 191
+        self.bus.send(gear.general.DTR0(191))
+        self.bus.send(gear.general.SetMaxLevel(address.Short(1)))
+        # After SetMaxLevel the level should be 191
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        self.assertEqual(resp.value, 191)
+        resp = self.bus.send(gear.general.QueryMaxLevel(address.Short(1)))
+        self.assertEqual(resp.value, 191)
+        # Level should not go above 191
+        self.bus.send(gear.general.DAPC(address.Short(1), 228))
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        self.assertEqual(resp.value, 191)
+
+    def test_fake_gear_set_min_above_max(self):
+        self.bus.send(gear.general.DTR0(188))
+        self.bus.send(gear.general.SetMaxLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryMinLevel(address.Short(0)))
+        self.assertEqual(resp.value, 1)
+        # Trying to set the minimum to larger than the maximum should result in the
+        # minimum being set the same as the maximum
+        self.bus.send(gear.general.DTR0(200))
+        self.bus.send(gear.general.SetMinLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryMinLevel(address.Short(0)))
+        self.assertEqual(resp.value, 188)
+
+    def test_fake_gear_set_max_below_min(self):
+        self.bus.send(gear.general.DTR0(188))
+        self.bus.send(gear.general.SetMinLevel(address.Short(0)))
+        # Trying to set the maximum to less than the minimum should result in the
+        # maximum being set the same as the minimum
+        self.bus.send(gear.general.DTR0(127))
+        self.bus.send(gear.general.SetMaxLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryMaxLevel(address.Short(0)))
+        self.assertEqual(resp.value, 188)
+
+    def test_fake_gear_set_scene(self):
+        # Initially all scenes are MASK
+        resp = self.bus.send(gear.general.QuerySceneLevel(address.Short(0), 0))
+        self.assertEqual(resp.value, "MASK")
+        # Set some scene values
+        self.bus.send(gear.general.DTR0(132))
+        self.bus.send(gear.general.SetScene(address.Short(0), 0))
+        self.bus.send(gear.general.DTR0(143))
+        self.bus.send(gear.general.SetScene(address.Short(1), 0))
+        self.bus.send(gear.general.DTR0(154))
+        self.bus.send(gear.general.SetScene(address.Short(2), 0))
+        self.bus.send(gear.general.DTR0(165))
+        self.bus.send(gear.general.SetScene(address.Short(3), 0))
+        # Outputs should be off
+        for ad in range(0, 4):
+            resp = self.bus.send(gear.general.QueryActualLevel(address.Short(ad)))
+            self.assertEqual(resp.value, 0)
+        # Activate the scene via broadcast
+        self.bus.send(gear.general.GoToScene(address.Broadcast(), 0))
+        # Outputs should be on now
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 132)
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        self.assertEqual(resp.value, 143)
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(2)))
+        self.assertEqual(resp.value, 154)
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(3)))
+        self.assertEqual(resp.value, 165)
+
+    def test_fake_gear_set_off(self):
+        # Set a higher minimum value
+        self.bus.send(gear.general.DTR0(22))
+        self.bus.send(gear.general.SetMinLevel(address.Short(0)))
+        self.bus.send(gear.general.DAPC(address.Short(0), 10))
+        # Ensure minimum level
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 22)
+        # Ensure DAPC of 0 still works
+        self.bus.send(gear.general.DAPC(address.Short(0), 0))
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 0)
+        # Ensure Off works
+        self.bus.send(gear.general.DAPC(address.Short(0), 10))
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 22)
+        self.bus.send(gear.general.Off(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.assertEqual(resp.value, 0)
+
+
+class TestFakeDevice(unittest.TestCase):
     def setUp(self):
         """
         Creates four fake devices, with addresses 0 to 3.
         """
         self.bus = fakes.Bus(
             [
-                fakes.Gear(0, memory_banks=(fakes.FakeBank0,)),
-                fakes.Gear(1, memory_banks=(fakes.FakeBank0,)),
-                fakes.Gear(2, memory_banks=(fakes.FakeBank0,)),
-                fakes.Gear(3, memory_banks=(fakes.FakeBank0,)),
+                fakes.Device(DeviceShort(0), memory_banks=(fakes.FakeDeviceBank0,)),
+                fakes.Device(DeviceShort(1), memory_banks=(fakes.FakeDeviceBank0,)),
+                fakes.Device(DeviceShort(2), memory_banks=(fakes.FakeDeviceBank0,)),
+                fakes.Device(DeviceShort(3), memory_banks=(fakes.FakeDeviceBank0,)),
             ]
         )
 
-    def test_fake_gear_dapc(self):
-        # The level should initialise to 0
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 0)
-        self.bus.send(general.DAPC(address.Short(0), 128))
-        # After DAPC the level should be 128
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 128)
-
-    def test_fake_gear_recall_max(self):
-        # The level should initialise to 0
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 0)
-        self.bus.send(general.RecallMaxLevel(address.Short(0)))
-        # After RecallMaxLevel the level should be 254
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 254)
-
-    def test_fake_gear_recall_min(self):
-        # The level should initialise to 0
-        resp = self.bus.send(general.QueryActualLevel(address.Short(1)))
-        self.assertEqual(resp.value, 0)
-        self.bus.send(general.RecallMinLevel(address.Short(1)))
-        # After RecallMaxLevel the level should be 1
-        resp = self.bus.send(general.QueryActualLevel(address.Short(1)))
-        self.assertEqual(resp.value, 1)
-
-    def test_fake_gear_set_min(self):
-        # Start with a level of 12
-        self.bus.send(general.DAPC(address.Short(0), 12))
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 12)
-        # Set minimum level to 22
-        self.bus.send(general.DTR0(22))
-        self.bus.send(general.SetMinLevel(address.Short(0)))
-        # After SetMinLevel the level should be 22
-        resp = self.bus.send(general.QueryMinLevel(address.Short(0)))
-        self.assertEqual(resp.value, 22)
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 22)
-        # Level should not go below 22
-        self.bus.send(general.DAPC(address.Short(0), 12))
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 22)
-
-    def test_fake_gear_set_max(self):
-        # Start with a level of 228
-        self.bus.send(general.DAPC(address.Short(1), 228))
-        resp = self.bus.send(general.QueryActualLevel(address.Short(1)))
-        self.assertEqual(resp.value, 228)
-        # Set maximum to 191
-        self.bus.send(general.DTR0(191))
-        self.bus.send(general.SetMaxLevel(address.Short(1)))
-        # After SetMaxLevel the level should be 191
-        resp = self.bus.send(general.QueryActualLevel(address.Short(1)))
-        self.assertEqual(resp.value, 191)
-        resp = self.bus.send(general.QueryMaxLevel(address.Short(1)))
-        self.assertEqual(resp.value, 191)
-        # Level should not go above 191
-        self.bus.send(general.DAPC(address.Short(1), 228))
-        resp = self.bus.send(general.QueryActualLevel(address.Short(1)))
-        self.assertEqual(resp.value, 191)
-
-    def test_fake_gear_set_min_above_max(self):
-        self.bus.send(general.DTR0(188))
-        self.bus.send(general.SetMaxLevel(address.Short(0)))
-        resp = self.bus.send(general.QueryMinLevel(address.Short(0)))
-        self.assertEqual(resp.value, 1)
-        # Trying to set the minimum to larger than the maximum should result in the
-        # minimum being set the same as the maximum
-        self.bus.send(general.DTR0(200))
-        self.bus.send(general.SetMinLevel(address.Short(0)))
-        resp = self.bus.send(general.QueryMinLevel(address.Short(0)))
-        self.assertEqual(resp.value, 188)
-
-    def test_fake_gear_set_max_below_min(self):
-        self.bus.send(general.DTR0(188))
-        self.bus.send(general.SetMinLevel(address.Short(0)))
-        # Trying to set the maximum to less than the minimum should result in the
-        # maximum being set the same as the minimum
-        self.bus.send(general.DTR0(127))
-        self.bus.send(general.SetMaxLevel(address.Short(0)))
-        resp = self.bus.send(general.QueryMaxLevel(address.Short(0)))
-        self.assertEqual(resp.value, 188)
-
-    def test_fake_gear_set_scene(self):
-        # Initially all scenes are MASK
-        resp = self.bus.send(general.QuerySceneLevel(address.Short(0), 0))
-        self.assertEqual(resp.value, "MASK")
-        # Set some scene values
-        self.bus.send(general.DTR0(132))
-        self.bus.send(general.SetScene(address.Short(0), 0))
-        self.bus.send(general.DTR0(143))
-        self.bus.send(general.SetScene(address.Short(1), 0))
-        self.bus.send(general.DTR0(154))
-        self.bus.send(general.SetScene(address.Short(2), 0))
-        self.bus.send(general.DTR0(165))
-        self.bus.send(general.SetScene(address.Short(3), 0))
-        # Outputs should be off
-        for ad in range(0, 4):
-            resp = self.bus.send(general.QueryActualLevel(address.Short(ad)))
-            self.assertEqual(resp.value, 0)
-        # Activate the scene via broadcast
-        self.bus.send(general.GoToScene(address.Broadcast(), 0))
-        # Outputs should be on now
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 132)
-        resp = self.bus.send(general.QueryActualLevel(address.Short(1)))
-        self.assertEqual(resp.value, 143)
-        resp = self.bus.send(general.QueryActualLevel(address.Short(2)))
-        self.assertEqual(resp.value, 154)
-        resp = self.bus.send(general.QueryActualLevel(address.Short(3)))
-        self.assertEqual(resp.value, 165)
-
-    def test_fake_gear_set_off(self):
-        # Set a higher minimum value
-        self.bus.send(general.DTR0(22))
-        self.bus.send(general.SetMinLevel(address.Short(0)))
-        self.bus.send(general.DAPC(address.Short(0), 10))
-        # Ensure minimum level
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 22)
-        # Ensure DAPC of 0 still works
-        self.bus.send(general.DAPC(address.Short(0), 0))
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 0)
-        # Ensure Off works
-        self.bus.send(general.DAPC(address.Short(0), 10))
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 22)
-        self.bus.send(general.Off(address.Short(0)))
-        resp = self.bus.send(general.QueryActualLevel(address.Short(0)))
-        self.assertEqual(resp.value, 0)
+    def test_fake_device_dtr012(self):
+        self.bus.send(device.general.DTR0(128))
+        self.bus.send(device.general.DTR1(1))
+        resp = self.bus.send(device.general.DTR2(254))
+        self.assertIsNone(resp)
+        for addr_int in range(3):
+            addr = DeviceShort(addr_int)
+            resp = self.bus.send(device.general.QueryContentDTR0(addr))
+            self.assertEqual(resp.value, 128)
+            resp = self.bus.send(device.general.QueryContentDTR1(addr))
+            self.assertEqual(resp.value, 1)
+            resp = self.bus.send(device.general.QueryContentDTR2(addr))
+            self.assertEqual(resp.value, 254)
 
 
 if __name__ == "__main__":

--- a/dali/tests/test_fakes.py
+++ b/dali/tests/test_fakes.py
@@ -1,8 +1,8 @@
 import unittest
 
 from dali.tests import fakes
-from dali import address, gear, device
-from dali.address import DeviceShort, GearShort
+from dali import address, command, gear, device
+from dali.address import DeviceShort, GearShort, InstanceNumber
 
 
 class TestFakeGear(unittest.TestCase):
@@ -183,6 +183,21 @@ class TestFakeDevice(unittest.TestCase):
             self.assertEqual(resp.value, 1)
             resp = self.bus.send(device.general.QueryContentDTR2(addr))
             self.assertEqual(resp.value, 254)
+
+    def test_fake_device_status(self):
+        for addr_int in range(3):
+            # Make sure QueryDeviceStatus works as expected
+            resp = self.bus.send(device.general.QueryDeviceStatus(DeviceShort(addr_int)))
+            self.assertIsInstance(resp, device.general.QueryDeviceStatusResponse)
+            # Make sure each device has four instances which respond as expected
+            for inst_num in range(4):
+                resp = self.bus.send(
+                    device.general.QueryInstanceEnabled(
+                        DeviceShort(addr_int), InstanceNumber(inst_num)
+                    )
+                )
+                self.assertIsInstance(resp, command.YesNoResponse)
+                self.assertTrue(resp.value)
 
 
 if __name__ == "__main__":

--- a/examples/async-serial-luba.py
+++ b/examples/async-serial-luba.py
@@ -78,8 +78,9 @@ async def listen_luba():
                     pass
 
     print("\nListening for DALI commands on the bus...\n")
+    rx_queue = driver.new_dali_rx_queue()
     while True:
-        cmd = await driver.wait_dali_rx()
+        cmd = await rx_queue.get()
         print(cmd)
 
 

--- a/examples/async-serial-luba.py
+++ b/examples/async-serial-luba.py
@@ -1,46 +1,65 @@
 """
 async-serial-luba.py - Example showing the usage of the LUBA driver
 
+This example shows how to use python-dali with a Lunatone RS232 LUBA protocol
+DALI interface. LUBA is a protocol defined by Lunatone for use in their
+devices, they publish the specification on their website:
+https://www.lunatone.com/wp-content/uploads/2021/04/LUBA_Protocol_EN.pdf
+
+It is assumed that an appropriate RS232 interface device is connected between
+the machine running python-dali and the Lunatone hardware, in writing this
+example an FTDI USB interface was used but any other compatible device will
+also work.
+
+The example scans the DALI bus for any DALI 24-bit "control devices",
+i.e. things like buttons, motion sensors, etc. (for now python-dali only
+supports push buttons, other types will be discovered but their event
+messages will be "unknown"); then for DALI 16-bit "control gear", i.e. lamps
+etc. Various bits of information from the devices is printed out, showing how
+to use things like the memory banks and a selected set of useful queries.
+
+
 
 This file is part of python-dali.
 
-python-dali is free software: you can redistribute it and/or modify it under the terms of the GNU
-Lesser General Public License as published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+python-dali is free software: you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-Lesser General Public License for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+details.
 
-You should have received a copy of the GNU Lesser General Public License along with this program.
-If not, see <https://www.gnu.org/licenses/>.
-
-
-
-This example shows how to use python-dali with a Lunatone RS232 LUBA protocol DALI interface.
-LUBA is a protocol defined by Lunatone for use in their devices, they publish the specification on
-their website: https://www.lunatone.com/wp-content/uploads/2021/04/LUBA_Protocol_EN.pdf
-
-It is assumed that an appropriate RS232 interface device is connected between the machine running
-python-dali and the Lunatone hardware, in writing this example an FTDI USB interface was used but
-any other compatible device will also work.
-"""
+You should have received a copy of the GNU Lesser General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>. """
 import asyncio
 import logging
 
-from dali.address import Broadcast, Short
+from dali.address import DeviceShort, GearBroadcast, GearShort, InstanceNumber
+from dali.command import NumericResponse
+from dali.device import pushbutton
+from dali.device.general import (
+    DTR0,
+    EventScheme,
+    QueryEventSchemeResponse,
+)
+from dali.device.sequences import SetEventFilters, SetEventSchemes
 from dali.driver.serial import DriverLubaRs232
 from dali.exceptions import DALISequenceError
 from dali.gear.general import DAPC, QueryControlGearPresent
+from dali.memory import info, location
 from dali.sequences import QueryDeviceTypes, QueryGroups
 
-# Define the path to the serial RS232 interface. The 'luba232' scheme tells the driver which
-# protocol to use - so far only the LUBA protocol is implemented, but others may be added in the
-# future
+# Define the path to the serial RS232 interface. The 'luba232' scheme tells
+# the driver which protocol to use - so far only the LUBA protocol is
+# implemented, but others may be added in the future
 URI = "luba232:/dev/ttyUSB0"
 
 
 async def listen_luba():
+    # Set up LUBA RS232 driver
     logger = logging.getLogger("dali")
     log_handler = logging.StreamHandler()
     log_formatter = logging.Formatter("%(asctime)s %(levelname)s:%(message)s")
@@ -50,16 +69,103 @@ async def listen_luba():
     logger.setLevel("INFO")
 
     driver = DriverLubaRs232(uri=URI)
-    await driver.connect()
+    await driver.connect(scan_dev_inst=True)
 
+    for dev_addr in {x[0] for x in driver.dev_inst_map.mapping.keys()}:
+        print(f"\nReading memory banks for device A²{dev_addr}:")
+        short = DeviceShort(dev_addr)
+        try:
+            dev_info = await driver.run_sequence(info.BANK_0.read_all(short))
+            print(f"{dev_info}\n")
+        except location.MemoryLocationNotImplemented:
+            pass
+
+    for dev_addr_inst, dev_type in driver.dev_inst_map.mapping.items():
+        dev_addr = dev_addr_inst[0]
+        inst_num = dev_addr_inst[1]
+        print(f"\nEnabling device/instance scheme for A²{dev_addr}:I{inst_num}")
+        sequence = SetEventSchemes(
+            device=DeviceShort(dev_addr),
+            instance=InstanceNumber(inst_num),
+            scheme=EventScheme.device_instance,
+        )
+        rsp = await driver.run_sequence(sequence)
+        if isinstance(rsp, QueryEventSchemeResponse):
+            if rsp.value == EventScheme.device_instance:
+                print("Success")
+                continue
+        print("Failed!")
+
+    for dev_addr_inst, dev_type in driver.dev_inst_map.mapping.items():
+        dev_addr = dev_addr_inst[0]
+        inst_num = dev_addr_inst[1]
+        if dev_type == pushbutton.instance_type:
+            print(f"\nEnabling pushbutton events for A²{dev_addr}:I{inst_num}")
+            filter_to_set = (
+                pushbutton.InstanceEventFilter.short_press
+                | pushbutton.InstanceEventFilter.long_press_start
+                | pushbutton.InstanceEventFilter.button_pressed
+                | pushbutton.InstanceEventFilter.long_press_repeat
+                | pushbutton.InstanceEventFilter.button_released
+                | pushbutton.InstanceEventFilter.long_press_stop
+                | pushbutton.InstanceEventFilter.button_stuck_free
+            )
+            sequence = SetEventFilters(
+                device=DeviceShort(dev_addr),
+                instance=InstanceNumber(inst_num),
+                filter_value=filter_to_set,
+            )
+            rsp = await driver.run_sequence(sequence)
+            if rsp == filter_to_set:
+                print("Success")
+            else:
+                print("Failed!")
+
+            # Test out getting some timer settings
+            rsp = await driver.send(
+                pushbutton.QueryShortTimer(
+                    device=DeviceShort(dev_addr),
+                    instance=InstanceNumber(inst_num),
+                )
+            )
+            if isinstance(rsp, NumericResponse):
+                short_timer = f"{rsp.value * 20} ms"
+            else:
+                short_timer = "<error>"
+
+            # Disable the double timer, this will mean short press events
+            # are fired immediately on button release
+            await driver.send(DTR0(0))
+            await driver.send(
+                pushbutton.SetDoubleTimer(
+                    device=DeviceShort(dev_addr),
+                    instance=InstanceNumber(inst_num),
+                )
+            )
+            rsp = await driver.send(
+                pushbutton.QueryDoubleTimer(
+                    device=DeviceShort(dev_addr),
+                    instance=InstanceNumber(inst_num),
+                )
+            )
+            if isinstance(rsp, NumericResponse):
+                double_timer = f"{rsp.value * 20} ms"
+            else:
+                double_timer = "<error>"
+            print(
+                f"A²{dev_addr}:I{inst_num} short timer: {short_timer}, "
+                f"double timer: {double_timer}"
+            )
+
+    # Test out DALI 16-bit control gear
     print("\nSending DAPC(254) to broadcast address")
-    await driver.send(DAPC(Broadcast(), 254))
+    await driver.send(DAPC(GearBroadcast(), 254))
     await asyncio.sleep(1.5)
     print("Sending DAPC(0) to broadcast address\n")
-    await driver.send(DAPC(Broadcast(), 0))
+    await driver.send(DAPC(GearBroadcast(), 0))
 
-    for ad in range(63):
-        short = Short(ad)
+    for ad in range(64):
+        short = GearShort(ad)
         rsp = await driver.send(QueryControlGearPresent(short))
         if rsp:
             if rsp.value:
@@ -72,11 +178,16 @@ async def listen_luba():
                 except DALISequenceError:
                     pass
                 try:
-                    gps = await driver.run_sequence(QueryGroups(short), progress=print)
-                    print(f"  Group Memberships: {list(gps) if gps else 'None'}")
+                    gps = await driver.run_sequence(
+                        QueryGroups(short), progress=print
+                    )
+                    print(
+                        f"  Group Memberships: {list(gps) if gps else 'None'}"
+                    )
                 except DALISequenceError:
                     pass
 
+    # Listen and print out any intercepted DALI commands
     print("\nListening for DALI commands on the bus...\n")
     rx_queue = driver.new_dali_rx_queue()
     while True:


### PR DESCRIPTION
IEC 62386 part 103 defines "event" messages, which can be sent by control devices to indicate various inputs or changes. This commit introduces support for encoding and decoding these messages, as well as a handful of new sequences for making it easier to work with them.

Support has been added for IEC 62386 part 301 "push button" devices, further device types should be simple enough to add in later. Unsupported types will be safely ignored by the library.