### PR TITLE
Add Lunatone LUBA RS232 driver

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install flake8 pytest pytest-asyncio pyserial-asyncio
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |

--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,8 @@ Library structure
 
     - ``hid`` - asyncio-based drivers for Tridonic DALI USB and hasseb DALI Master
 
+    - ``serial`` - asyncio-based driver for Lunatone LUBA RS232 interfaces
+
   - ``exceptions`` - DALI related exceptions
 
   - ``frame`` - Forward and backward frames; stable

--- a/dali/command.py
+++ b/dali/command.py
@@ -191,7 +191,10 @@ class Command(metaclass=_CommandTracker):
     devicetype = 0
 
     def __init__(self, f):
-        assert isinstance(f, frame.ForwardFrame)
+        if not isinstance(f, frame.ForwardFrame):
+            raise TypeError(
+                f"{self.__class__.__name__} expected a ForwardFrame, not a {type(f)}"
+            )
         self._data = f
 
     _framesizes = {}

--- a/dali/driver/serial.py
+++ b/dali/driver/serial.py
@@ -1,0 +1,819 @@
+"""
+serial.py - Driver for serial-based DALI interfaces, including the Lunatone RS232 LUBA device
+
+
+This file is part of python-dali.
+
+python-dali is free software: you can redistribute it and/or modify it under the terms of the GNU
+Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with this program.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from enum import Enum
+from functools import reduce
+from operator import xor
+from typing import Any, Callable, Generator, NamedTuple, Optional, Union
+from urllib.parse import ParseResult, urlparse, urlunparse
+
+import serial_asyncio
+
+from dali import command, frame, gear, sequences
+from dali.driver import trace_logging  # noqa: F401
+
+_LOG = logging.getLogger("dali.driver")
+
+
+class DriverSerialBase:
+    uri_scheme = ""
+
+    def __init__(self, uri: Union[str, ParseResult]):
+        """
+        Sets up everything necessary for the driver to be able to start, but doesn't
+        actually create the connection yet - that must be done by awaiting the 'connect()'
+        coroutine.
+
+        :param uri: A urllib ParseResult, or a string, of the URI to be used in initialising the
+        driver. Depending on the specific driver type this will probably include the path to the
+        serial device, e.g. 'luba232:/dev/ttyUSB0'
+        """
+        if self.__class__.__name__ == "DriverSerialBase":
+            raise RuntimeError("DriverSerialBase cannot be instantiated directly")
+
+        try:
+            uri.path
+        except AttributeError:
+            uri = urlparse(uri)
+
+        if uri.scheme != self.uri_scheme:
+            raise TypeError(
+                f"Cannot create a {self.__class__.__name__} "
+                f"instance with a scheme of {uri.scheme}"
+            )
+
+        self.uri = uri
+        self._connected = asyncio.Event()
+        self.transaction_lock = asyncio.Lock()
+
+    def __repr__(self):
+        return f'{self.__class__.__name__}("{urlunparse(self.uri)}")'
+
+    def __hash__(self):
+        return hash(self.uri)
+
+    async def connect(self) -> None:
+        """
+        Perform the connection to the physical device. This may take some time, depending on how
+        the hardware works.
+        """
+        raise NotImplementedError("'connect()' needs to be implemented in a subclass")
+
+    @property
+    def is_connected(self) -> bool:
+        """
+        Flags whether the underlying transport is connected and ready for use
+
+        :return: Boolean, true if connection is ready
+        """
+        return self._connected.is_set()
+
+    async def wait_connected(self) -> None:
+        """
+        Blocks until the underlying transport is connected and ready for use
+
+        :return: None
+        """
+        await self._connected.wait()
+
+    async def send(
+        self, msg: command.Command, in_transaction: bool = False
+    ) -> Optional[command.Response]:
+        """
+        Send one DALI command over the bus using the driver. If the command expects a response
+        this will be returned.
+
+        :param msg: A Command object to send over the DALI bus
+        :param in_transaction: Boolean flag to indicate if this `send()` call is part of a
+        transaction, i.e. where the driver will block sending other messages until the transaction
+        is complete. This is typically only needed internally, by the `run_sequence()` method.
+        :return: Either None if no response is expected, or a Response object
+        """
+        raise NotImplementedError("'send()' needs to be implemented in a subclass")
+
+    async def wait_dali_rx(self) -> command.Command:
+        """
+        Async method which waits for a DALI command to be received from the underlying device,
+        i.e. this method reports any commands which were seen by listening to the DALI bus.
+        Returns on each command that is received, await again to get the next command.
+
+        The underlying implementation uses a queue, so only one caller should await this method
+        at a time - otherwise unexpected behaviour will occur.
+
+        Note that this does not return any responses, e.g. an answer to a query - those are
+        returned to the caller when using the `send()` method.
+
+        :return: A received DALI command
+        """
+        raise NotImplementedError(
+            "'wait_dali_rx()' needs to be implemented in a subclass"
+        )
+
+    async def run_sequence(
+        self,
+        seq: Generator[
+            command.Command,  # Sequences yield commands to send
+            command.Response,  # Sequences get sent the response from the previous command
+            Any,  # The return type depends specifically on the sequence
+        ],
+        progress: Optional[Callable[[str | sequences.progress], None]] = None,
+    ) -> Any:
+        """
+        Run a command sequence as a transaction. Implements the same API as the 'hid' drivers.
+
+        :param seq: A "generator" function to use as a sequence. These are available in various
+        places in the python-dali library.
+        :param progress: A function to call with progress updates, used by some sequences to
+        provide status information. The function must accept a single argument. A suitable example
+        is `progress=print` to use the built-in `print()` function.
+        :return: Depends on the sequence being used
+        """
+        async with self.transaction_lock:
+            response = None
+            try:
+                while True:
+                    try:
+                        # Note that 'send()' here refers to the Python 'generator' paradigm,
+                        # not to the DALI driver!
+                        cmd = seq.send(response)
+                    except StopIteration as r:
+                        return r.value
+                    response = None
+                    if isinstance(cmd, sequences.sleep):
+                        await asyncio.sleep(cmd.delay)
+                    elif isinstance(cmd, sequences.progress):
+                        if progress:
+                            progress(cmd)
+                    else:
+                        if cmd.devicetype != 0:
+                            # The 'send()' calls here *do* refer to the DALI transmit method
+                            await self.send(
+                                gear.general.EnableDeviceType(cmd.devicetype),
+                                in_transaction=True,
+                            )
+                        response = await self.send(cmd, in_transaction=True)
+            finally:
+                seq.close()
+
+
+def drivers_map() -> dict[str, type[DriverSerialBase]]:
+    """
+    Return a dict that maps each known driver URI scheme to the relevant driver class. This
+    can be used to initialise drivers based on a given URI, example:
+    ```
+    driver = drivers_map()["luba232"]
+    ```
+    """
+    # TODO: this could be tracked in a metaclass, to prevent recreating on each use
+    return {driver.uri_scheme: driver for driver in DriverSerialBase.__subclasses__()}
+
+
+class DriverLubaRs232(DriverSerialBase):
+    uri_scheme = "luba232"
+    timeout_rx = 0.025
+    timeout_tx_confirm = 1.0  # TX might take some time if the bus is busy
+    timeout_connect = 1.0
+
+    class LubaCmd(Enum):
+        """
+        All supported LUBA command codes. Refer §2 of Lunatone's documentation on LUBA:
+        https://www.lunatone.com/wp-content/uploads/2021/04/LUBA_Protocol_EN.pdf
+        """
+
+        READ_WRITE_SETTINGS_CMD = 0x2A
+        READ_WRITE_SETTINGS_RSP = 0x2B
+        READ_STATUS_CMD = 0x2C
+        READ_STATUS_RSP = 0x2D
+        QUERY_DEVICE_INFO_CMD = 0x20
+        QUERY_DEVICE_INFO_RSP = 0x21
+        EVENT_MESSAGE = 0x31
+        ADD_DALI_FRAME_TO_TX_CMD = 0x32
+        ADD_DALI_FRAME_TO_TX_RSP = 0x33
+        ADD_16DALI_FRAME_TO_TX_CMD = 0x34
+        ADD_16DALI_FRAME_TO_TX_RSP = 0x35
+        ADD_24DALI_FRAME_TO_TX_CMD = 0x36
+        ADD_24DALI_FRAME_TO_TX_RSP = 0x37
+
+    class LubaDeviceInfo(NamedTuple):
+        """
+        Named tuple for storing a set of information about the LUBA device
+        """
+
+        gtin: int
+        id: int
+        pcb_ver: int
+        assembly_ver: int
+        article_num: int
+
+    class LubaDeviceSettings(NamedTuple):
+        """
+        Named tuple for storing a set of information about the LUBA device
+        """
+
+        mode: int
+        event_filter: int
+
+    class LubaProtocol(asyncio.Protocol):
+        """
+        This class is internally used by DriverLubaRs232 to implement a state machine for
+        decoding the incoming serial bytes into LUBA messages, which in turn wrap DALI frames.
+        The class also handles encoding DALI frames into LUBA messages, setting the appropriate
+        flags etc.
+        """
+
+        MAX_LEN = 24
+        EVENT_TYPE_MASK = 0b11000000
+        EVENT_INFO_MASK = 0b00111111
+
+        class ReadState(Enum):
+            """
+            Enum of states used in the receiver state machine
+            """
+
+            WAIT_START = 1
+            WAIT_COMMAND = 2
+            WAIT_LENGTH = 3
+            LOOP_READ = 4
+            WAIT_CHECKSUM = 5
+
+        class LubaMsgTxConf(NamedTuple):
+            """
+            Named tuple used to enqueue messages along with their transmit ID
+            """
+
+            tx_id: int
+            message: Optional[command.Command] = None
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.transport = None
+
+            self._queue_rx_dali = asyncio.Queue()
+            self._queue_rx_raw_dali = asyncio.Queue()
+            self._queue_rx_luba_cmd = asyncio.Queue()
+            self._queue_tx_conf = asyncio.Queue()
+            self._tx_lock = asyncio.Lock()
+            self._rx_state = None
+            self.rx_idle = asyncio.Event()
+            self._buffer = None
+            self._rx_expected_len = None
+            self._rx_received_len = None
+            self._connected = asyncio.Event()
+            self._dev_info: Optional[DriverLubaRs232.LubaDeviceInfo] = None
+
+            self.reset()
+
+        @property
+        def rx_state(self) -> ReadState:
+            return self._rx_state
+
+        @rx_state.setter
+        def rx_state(self, state: ReadState):
+            if not isinstance(state, self.ReadState):
+                raise TypeError(f"rx_state must be a ReadState enum, not {type(state)}")
+
+            self._rx_state = state
+            if state == self.ReadState.WAIT_START:
+                self.rx_idle.set()
+            else:
+                self.rx_idle.clear()
+
+        def reset(self):
+            """
+            Returns the state machine to "WAIT_START"
+            """
+            self.rx_state = self.ReadState.WAIT_START
+            self._buffer = [None] * self.MAX_LEN
+            self._rx_expected_len = None
+            self._rx_received_len = 0
+
+        async def wait_dali_command(self) -> command.Command:
+            """
+            Async method which waits for a DALI command to be received from the LUBA device, then
+            returns that frame.
+
+            :return: A received DALI command, as a Command instance
+            """
+            return await self._queue_rx_dali.get()
+
+        async def wait_dali_raw_response(self) -> int:
+            """
+            Async method which waits for a raw (i.e. un-decoded) DALI frame to be received from
+            the LUBA device.
+
+            :return: A received DALI frame, as an int
+            """
+            return await self._queue_rx_raw_dali.get()
+
+        @staticmethod
+        def _insert_checksum(in_ints: list[int]) -> None:
+            in_ints[-1] = reduce(xor, in_ints[1:-1])
+
+        async def send_dali_command(self, tx: command.Command) -> None:
+            """
+            Sends a variable length DALI command (16 or 24 bits), waiting until the LUBA device
+            confirms it has sent the message before returning the frame ID.
+
+            :param tx: A single DALI command to send
+            """
+            # Make sure the serial interface is not in the process of reading data before we send
+            await self.rx_idle.wait()
+
+            dali_ints = tx.frame.as_byte_sequence
+            if not len(dali_ints) in (2, 3):
+                raise ValueError(
+                    f"Only works with 16 or 24 bit messages, not {8*len(dali_ints)}"
+                )
+            # Determine the message priority - standard commands and DAPC are high priority,
+            # others are low
+            if (
+                isinstance(tx, gear.general._StandardCommand)
+                and not tx.response
+                and not tx.sendtwice
+            ) or isinstance(tx, gear.general.DAPC):
+                priority = 0b00000010  # Priority 2 (second-highest)
+            else:
+                priority = 0b00000101  # Priority 5 (lowest)
+            luba_mode = 0
+            luba_mode |= priority
+            luba_mode |= 0b10000000 if tx.sendtwice else 0  # "Send Twice" flag
+            tx_ints = [
+                0x59,  # ASCII 'Y'
+                DriverLubaRs232.LubaCmd.ADD_DALI_FRAME_TO_TX_CMD.value,  # LUBA Command
+                7,  # Length
+                0,  # DALI bus selector (RS232 device only has one bus)
+                8 * len(dali_ints),  # No. of bits in DALI frame
+                luba_mode,
+                dali_ints[0],  # Data, big-endian
+                dali_ints[1],  # Data, big-endian
+                0 if len(dali_ints) == 2 else dali_ints[2],  # Data, big-endian
+                0,  # Pad out to four bytes, to fit LUBA frame
+                None,  # Checksum
+            ]
+            # Fill in the checksum
+            self._insert_checksum(tx_ints)
+
+            # Use a mutex to ensure only one message is sent at a time, waiting for the LUBA
+            # device to confirm before sending another
+            async with self._tx_lock:
+                _LOG.debug(f"DALI sending message: {tx}")
+                _LOG.trace(
+                    f"LUBA frame to send: {[f'0x{data:02x}' for data in tx_ints]}"
+                )
+                self.transport.write(bytearray(tx_ints))
+
+                # Wait for the LUBA device to respond, considering whether the message
+                # is sent twice or not
+                confirm_count = 2 if tx.sendtwice else 1
+                while confirm_count > 0:
+                    confirm = await asyncio.wait_for(
+                        self._queue_tx_conf.get(),
+                        timeout=DriverLubaRs232.timeout_tx_confirm,
+                    )
+                    if confirm.message.frame == tx.frame:
+                        _LOG.trace(
+                            f"LUBA device reports message '{tx}' sent, "
+                            f"with ID {confirm.tx_id}"
+                        )
+                    else:
+                        _LOG.error(
+                            "Expected LUBA device to confirm transmission of message "
+                            f"'{tx}', but got a confirmation for '{confirm.message}'"
+                        )
+                    confirm_count -= 1
+            # Release the lock
+
+            return confirm.tx_id
+
+        async def send_device_info_query(self) -> None:
+            """
+            Query some basic information from the LUBA device
+            """
+            # Use a mutex to ensure only one message is sent at a time
+            async with self._tx_lock:
+                _LOG.debug("Querying LUBA device info")
+                tx_ints = [
+                    0x59,  # ASCII 'Y'
+                    DriverLubaRs232.LubaCmd.QUERY_DEVICE_INFO_CMD.value,  # LUBA Command
+                    1,  # Length
+                    0,  # Request set "0" information
+                    None,  # Checksum
+                ]
+                # Fill in the checksum
+                self._insert_checksum(tx_ints)
+
+                _LOG.trace(
+                    f"LUBA frame to send: {[f'0x{data:02x}' for data in tx_ints]}"
+                )
+                self.transport.write(bytearray(tx_ints))
+
+                # Wait for the LUBA device to respond
+                dev_info = await asyncio.wait_for(
+                    self._queue_rx_luba_cmd.get(),
+                    timeout=DriverLubaRs232.timeout_tx_confirm,
+                )
+            # Release transmit mutex
+
+            if not isinstance(dev_info, DriverLubaRs232.LubaDeviceInfo):
+                _LOG.error(f"Expected a LubaDeviceInfo, but got: {dev_info}")
+                return
+
+        async def send_device_settings(self) -> None:
+            """
+            The implementation of the LUBA protocol assumes a certain configuration of the device,
+            this method ensures this configuration is set up correctly
+            """
+            # Use a mutex to ensure only one message is sent at a time
+            async with self._tx_lock:
+                _LOG.debug("Sending LUBA device settings")
+                mode_settings = 0b00000000
+                event_settings = 0b00010010
+                tx_ints = [
+                    0x59,  # ASCII 'Y'
+                    DriverLubaRs232.LubaCmd.READ_WRITE_SETTINGS_CMD.value,  # LUBA Command
+                    2,  # Length
+                    mode_settings,
+                    event_settings,
+                    None,  # Checksum
+                ]
+                # Fill in the checksum
+                self._insert_checksum(tx_ints)
+
+                _LOG.trace(
+                    f"LUBA frame to send: {[f'0x{data:02x}' for data in tx_ints]}"
+                )
+                self.transport.write(bytearray(tx_ints))
+
+                # Wait for the LUBA device to respond
+                dev_settings = await asyncio.wait_for(
+                    self._queue_rx_luba_cmd.get(),
+                    timeout=DriverLubaRs232.timeout_tx_confirm,
+                )
+            # Release transmit mutex
+
+            if not isinstance(dev_settings, DriverLubaRs232.LubaDeviceSettings):
+                _LOG.error(f"Expected a LubaDeviceSettings, but got: {dev_settings}")
+                return
+            if (
+                dev_settings.mode != mode_settings
+                or dev_settings.event_filter != event_settings
+            ):
+                msg = "Failed to set LUBA device settings!"
+                _LOG.critical(msg)
+                raise RuntimeError(msg)
+
+            _LOG.trace("Successfully set LUBA device settings")
+
+        def _process_byte(self, rx_int: int) -> None:
+            if not isinstance(rx_int, int):
+                raise TypeError(
+                    f"Got an item of type: {type(rx_int)}, expected an integer"
+                )
+
+            # Handle each state of the state machine
+            if self._rx_state == self.ReadState.WAIT_START:
+                # In the 'WAIT_START' state we expect an ASCII 'Y', or hex 0x59
+                self._buffer[0] = rx_int
+                if rx_int == 0x59:
+                    _LOG.trace("LUBA message start")
+                    self._rx_state = self.ReadState.WAIT_COMMAND
+                else:
+                    _LOG.debug(f"LUBA invalid start pattern: 0x{rx_int:02x}")
+                return
+
+            elif self._rx_state == self.ReadState.WAIT_COMMAND:
+                # In the 'WAIT_COMMAND' state the next byte will be the LUBA command code
+                self._buffer[1] = rx_int
+                try:
+                    rx_cmd = DriverLubaRs232.LubaCmd(self._buffer[1])
+                    _LOG.trace(f"LUBA command number: {rx_cmd}")
+                except ValueError:
+                    _LOG.warning(f"LUBA command number not understood: 0x{rx_int:02x}")
+                self._rx_state = self.ReadState.WAIT_LENGTH
+                return
+
+            elif self._rx_state == self.ReadState.WAIT_LENGTH:
+                # In the 'WAIT_LENGTH' state the next byte will be the length
+                self._buffer[2] = rx_int
+                if 0 < rx_int < self.MAX_LEN:
+                    _LOG.trace(f"LUBA payload length: {rx_int}")
+                    self._rx_expected_len = rx_int
+                    self._rx_state = self.ReadState.LOOP_READ
+                else:
+                    _LOG.warning(f"LUBA payload length of {rx_int} is invalid!")
+                    self.reset()
+                return
+
+            elif self._rx_state == self.ReadState.LOOP_READ:
+                # Read bytes, up to the maximum expected length
+                self._rx_received_len += 1
+                self._buffer[2 + self._rx_received_len] = rx_int
+
+                # Once all payload bytes are read, the final byte will be the checksum
+                if self._rx_received_len == self._rx_expected_len:
+                    self._rx_state = self.ReadState.WAIT_CHECKSUM
+                return
+
+            elif self._rx_state == self.ReadState.WAIT_CHECKSUM:
+                # In the 'WAIT_CHECKSUM' state, the next byte will be the checksum
+                self._buffer[self._rx_received_len + 3] = rx_int
+
+                # We now have a full frame
+                received_data = tuple(self._buffer[0 : self._rx_received_len + 4])
+                _LOG.trace(f"Raw data: {[f'0x{data:02x}' for data in received_data]}")
+
+                # Validate the checksum: XOR all values, excluding the synchronisation and checksum
+                check = reduce(xor, received_data[1:-1])
+
+                if check != rx_int:
+                    _LOG.warning(
+                        f"LUBA checksum failure! Calculated: {check}, Expected: {rx_int}"
+                    )
+                    _LOG.trace(received_data)
+                    self.reset()
+                    return
+                else:
+                    _LOG.trace("LUBA checksum passed, full frame received")
+                    try:
+                        rx_cmd = DriverLubaRs232.LubaCmd(self._buffer[1])
+                        if rx_cmd == DriverLubaRs232.LubaCmd.EVENT_MESSAGE:
+                            self._process_luba_event(received_data)
+                        elif rx_cmd == DriverLubaRs232.LubaCmd.ADD_DALI_FRAME_TO_TX_RSP:
+                            self._process_luba_response_dali_frame_to_tx(received_data)
+                        elif rx_cmd == DriverLubaRs232.LubaCmd.QUERY_DEVICE_INFO_RSP:
+                            self._process_luba_response_device_info(received_data)
+                        elif rx_cmd == DriverLubaRs232.LubaCmd.READ_WRITE_SETTINGS_RSP:
+                            self._process_luba_response_settings(received_data)
+                    except ValueError:
+                        _LOG.warning(
+                            f"LUBA unhandled message type: 0x{self._buffer[1]:02x}"
+                        )
+                    self.reset()
+                    return
+            else:
+                raise RuntimeError(f"Invalid state: {self._rx_state}")
+
+        def _process_luba_event(self, received_data: tuple):
+            """
+            Handle a LUBA 'event' message, typically these are received when a DALI frame was
+            observed on the bus by the LUBA device
+            """
+            if (
+                DriverLubaRs232.LubaCmd(self._buffer[1])
+                != DriverLubaRs232.LubaCmd.EVENT_MESSAGE
+            ):
+                raise ValueError(
+                    f"Wrong event type 0x{self._buffer[1]:02x}, expected 0x31"
+                )
+
+            payload = received_data[3:-1]
+
+            # Bytes 0-1 of payload are the 'time tick'
+            time_tick = int.from_bytes(bytes(payload[0:2]), byteorder="big")
+            _LOG.trace(f"LUBA Event Time tick: {time_tick}")
+            # Byte 2 of payload is the 'DALI line'
+            _LOG.trace(f"LUBA Event DALI line: {payload[2]}")
+            # Byte 3 of payload is the "Status", further broken down by bit fields
+            status_int = payload[3]
+            event_type = (status_int & self.EVENT_TYPE_MASK) >> 6
+            event_info = status_int & self.EVENT_INFO_MASK
+            _LOG.trace(f"LUBA Event type: {event_type}, Event info: {event_info}")
+
+            # Event type 0: DALI frame was sent
+            # Byte 4 is the transmitted frame ID
+            # Bytes 5 onwards are the transmitted DALI frame
+            if event_type == 0:
+                tx_id = payload[4]
+                tx_dali = payload[5:]
+                # Decode the command, for logging and debugging
+                dbg_str = ""
+                try:
+                    dali_command = command.Command.from_frame(
+                        frame.Frame(bits=8 * len(tx_dali), data=tx_dali)
+                    )
+                except:
+                    dali_command = None
+                    pass
+                luba_tx_info = self.LubaMsgTxConf(tx_id=tx_id, message=dali_command)
+                _LOG.trace(
+                    f"LUBA DALI frame {luba_tx_info.tx_id} "
+                    f"transmitted: {luba_tx_info.message}"
+                )
+                self._queue_tx_conf.put_nowait(luba_tx_info)
+            # Event type 2: DALI frame was received
+            # Bytes 4 onwards are the received DALI frame
+            if event_type == 2:
+                rx_dali = payload[4:]
+                _LOG.trace(
+                    f"LUBA DALI frame received: {[f'0x{data:02x}' for data in rx_dali]}"
+                )
+
+                if len(rx_dali) == 1:
+                    # An 8-bit frame is a response, don't try to decipher it here because
+                    # it depends on context which the 'send()' routine will have to handle
+                    _LOG.trace(f"Adding raw DALI response to queue: '{rx_dali[0]}'")
+                    self._queue_rx_raw_dali.put_nowait(rx_dali[0])
+                else:
+                    # A 16 or 24-bit frame is an intercepted DALI command, it can be deciphered
+                    # into a Command object
+                    dali_frame = frame.Frame(bits=8 * len(rx_dali), data=rx_dali)
+                    try:
+                        dali_command = command.Command.from_frame(dali_frame)
+                    except TypeError:
+                        _LOG.error(
+                            f"Failed to decode DALI command! Frame: {dali_frame}"
+                        )
+                        return
+
+                    _LOG.debug(f"Adding DALI command to queue: {dali_command}")
+                    self._queue_rx_dali.put_nowait(dali_command)
+
+        def _process_luba_response_dali_frame_to_tx(self, received_data: tuple):
+            """
+            Handle a LUBA 'ADD DALI FRAME TO TX BUFFER' response message
+            """
+            if (
+                DriverLubaRs232.LubaCmd(self._buffer[1])
+                != DriverLubaRs232.LubaCmd.ADD_DALI_FRAME_TO_TX_RSP
+            ):
+                raise ValueError(
+                    f"Wrong event type 0x{self._buffer[1]:02x}, expected 0x33"
+                )
+
+            payload_length = received_data[2]
+            if payload_length == 1:
+                error_code = received_data[3]
+                _LOG.error(f"LUBA device reports error in transmission: {error_code}")
+            elif payload_length == 2:
+                tx_id = received_data[3]
+                _LOG.trace(f"LUBA device reports transmission accepted, ID: {tx_id}")
+            else:
+                raise ValueError(f"Invalid LUBA response length: {payload_length}")
+
+        def _process_luba_response_device_info(self, received_data: tuple):
+            """
+            Handle a received "QUERY DEVICE INFO" response message
+            """
+            if (
+                DriverLubaRs232.LubaCmd(self._buffer[1])
+                != DriverLubaRs232.LubaCmd.QUERY_DEVICE_INFO_RSP
+            ):
+                raise ValueError(
+                    f"Wrong event type 0x{self._buffer[1]:02x}, expected 0x21"
+                )
+
+            # QUERY DEVICE INFO supports two "sets" of data, this driver will only ever request
+            # set "0", so it is safe enough to assume that this is what the response refers to
+            info = DriverLubaRs232.LubaDeviceInfo(
+                gtin=int.from_bytes(bytes(received_data[3:9]), byteorder="big"),
+                id=int.from_bytes(bytes(received_data[9:17]), byteorder="big"),
+                pcb_ver=received_data[17],
+                assembly_ver=received_data[18],
+                article_num=int.from_bytes(
+                    bytes(received_data[19:23]), byteorder="big"
+                ),
+            )
+            _LOG.info(f"Received device info: {info}")
+            if info.article_num != 24166096:
+                _LOG.warning(
+                    "DriverLubaRs232 has only been tested with Lunatone article "
+                    f"nr. 24166096, not nr. {info.article_num}"
+                )
+            self._dev_info = info
+            self._queue_rx_luba_cmd.put_nowait(info)
+
+        def _process_luba_response_settings(self, received_data: tuple):
+            """
+            Handle a received "READ / WRITE SETTINGS" response message
+            """
+            if (
+                DriverLubaRs232.LubaCmd(self._buffer[1])
+                != DriverLubaRs232.LubaCmd.READ_WRITE_SETTINGS_RSP
+            ):
+                raise ValueError(
+                    f"Wrong event type 0x{self._buffer[1]:02x}, expected 0x2B"
+                )
+
+            settings = DriverLubaRs232.LubaDeviceSettings(
+                mode=received_data[3], event_filter=received_data[4]
+            )
+            _LOG.info(f"Received device settings: {settings}")
+            self._queue_rx_luba_cmd.put_nowait(settings)
+
+        def connection_made(self, transport):
+            self.transport = transport
+            _LOG.info(f"Serial port opened: {transport}")
+            self._connected.set()
+
+        def data_received(self, data):
+            _LOG.trace(f"Serial data received: {data}")
+            for rx in data:
+                self._process_byte(rx)
+
+        def connection_lost(self, exc):
+            _LOG.info("Serial port closed")
+            self.transport.loop.stop()
+
+        @property
+        def connected(self) -> asyncio.Event:
+            return self._connected
+
+        @property
+        def device_info(self) -> Optional[DriverLubaRs232.LubaDeviceInfo]:
+            return self._dev_info
+
+    def __init__(self, *, uri: Union[str, ParseResult]):
+        super().__init__(uri)
+
+        self.serial_path = self.uri.path
+        _LOG.info(f"Initialising luba232 driver for '{self.serial_path}'")
+        self._transport: Optional[serial_asyncio.SerialTransport] = None
+        self._protocol: Optional[DriverLubaRs232.LubaProtocol] = None
+
+    async def connect(self) -> None:
+        if self.is_connected:
+            _LOG.warning(f"'connect()' called but luba232 driver already connected")
+            return
+
+        # TODO: Add failure/retry handling
+        self._transport, self._protocol = await serial_asyncio.create_serial_connection(
+            loop=asyncio.get_event_loop(),
+            protocol_factory=DriverLubaRs232.LubaProtocol,
+            url=self.serial_path,
+            baudrate=38400,
+        )
+        try:
+            await asyncio.wait_for(
+                self._protocol.connected.wait(),
+                timeout=DriverLubaRs232.timeout_connect,
+            )
+        except asyncio.exceptions.TimeoutError as exc:
+            _LOG.critical(f"Timeout waiting for driver to connect: {exc}")
+            raise
+
+        await self._protocol.send_device_info_query()
+        await self._protocol.send_device_settings()
+        self._connected.set()
+
+    async def send(
+        self, msg: command.Command, in_transaction: bool = False
+    ) -> Optional[command.Response]:
+        # Only send if the driver is connected
+        if not self.is_connected:
+            _LOG.critical(f"DALI driver cannot send, not connected: {self}")
+            raise IOError("DALI driver cannot send, not connected")
+
+        response = None
+        # "Send" each message, one at a time, and figure out what the dummy response should be
+        if not in_transaction:
+            await self.transaction_lock.acquire()
+        try:
+            await self._protocol.send_dali_command(msg)
+            if msg.is_query:
+                response = command.Response(None)
+                while True:
+                    try:
+                        raw_rsp = await asyncio.wait_for(
+                            self._protocol.wait_dali_raw_response(),
+                            timeout=DriverLubaRs232.timeout_rx,
+                        )
+                    except asyncio.exceptions.TimeoutError:
+                        _LOG.debug(f"DALI response timeout, from message: {msg}")
+                        break
+                    if isinstance(raw_rsp, int):
+                        response = msg.response(frame.BackwardFrame(raw_rsp))
+                        _LOG.debug(f"DALI response received: {raw_rsp}")
+                        break
+                    else:
+                        _LOG.warning(
+                            "DALI response expected to be 'int' but got type "
+                            f"'{type(raw_rsp)}': {raw_rsp}"
+                        )
+                        raw_rsp = None
+                        continue
+        finally:
+            if not in_transaction:
+                self.transaction_lock.release()
+
+        return response
+
+    async def wait_dali_rx(self) -> command.Command:
+        return await self._protocol.wait_dali_command()

--- a/dali/driver/trace_logging.py
+++ b/dali/driver/trace_logging.py
@@ -1,0 +1,64 @@
+"""
+trace_logging.py - Additional logging level, for very verbose development logging
+
+
+This file is part of python-dali.
+
+python-dali is free software: you can redistribute it and/or modify it under the terms of the GNU
+Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with this program.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+import logging
+
+_LOG = logging.getLogger(f"dali")
+_logging_trace_created = False
+
+
+def add_logging_level(level_name: str, level_num: int):
+    """
+    Original source: https://stackoverflow.com/a/35804945
+
+    Comprehensively adds a new logging level to the `logging` module and the
+    currently configured logging class.
+
+    `levelName` becomes an attribute of the `logging` module with the value
+    `levelNum`.
+    """
+    method_name = level_name.lower()
+
+    if hasattr(logging, level_name):
+        _LOG.warning(f"{level_name} already defined in logging module")
+        return
+    if hasattr(logging, method_name):
+        _LOG.warning(f"{method_name} already defined in logging module")
+        return
+    if hasattr(logging.getLoggerClass(), method_name):
+        _LOG.warning(f"{method_name} already defined in logger class")
+        return
+
+    # This method was inspired by the answers to Stack Overflow post
+    # http://stackoverflow.com/q/2183233/2988730, especially
+    # http://stackoverflow.com/a/13638084/2988730
+    def logForLevel(self, message, *args, **kwargs):
+        if self.isEnabledFor(level_num):
+            self._log(level_num, message, args, **kwargs)
+
+    def logToRoot(message, *args, **kwargs):
+        logging.log(level_num, message, *args, **kwargs)
+
+    logging.addLevelName(level_num, level_name)
+    setattr(logging, level_name, level_num)
+    setattr(logging.getLoggerClass(), method_name, logForLevel)
+    setattr(logging, method_name, logToRoot)
+
+
+if not _logging_trace_created:
+    add_logging_level("TRACE", logging.DEBUG - 5)
+    _logging_trace_created = True

--- a/dali/tests/fakes_serial.py
+++ b/dali/tests/fakes_serial.py
@@ -1,0 +1,331 @@
+"""
+fakes_serial.py - A mock implementation of a serial driver, for testing without relying on hardware
+
+
+This file is part of python-dali.
+
+python-dali is free software: you can redistribute it and/or modify it under the terms of the GNU
+Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with this program.
+If not, see <https://www.gnu.org/licenses/>.
+
+
+
+DriverSerialDummy provides a basic mock DALI bus, with fake devices connected to it. These fake
+devices can respond to a limited subset of DALI commands - useful in testing logic of other parts
+of the library.
+
+DriverSerialDummy instances are created using a path to a file, rather than a real serial device.
+This file is used to log all of the DALI commands which would be sent out over the DALI bus if
+using a "real" driver. During tests, the log file can be read to verify the expected command was
+sent.
+
+Three types of devices are emulated, DT6 LEDs, DT7 relays, and the Lunatone OEM-specific "Jalousie"
+relay (used for controlling blinds). The number of each dummy device to create is specified in a
+query string, after the path to the logfile, using the keys 'led', 'relay', and 'cover'.
+
+Example:
+```
+dummy_driver = DriverSerialDummy(uri="dummy:/tmp/dali0.txt?led=2&cover=2&relay=4")
+await dummy_driver.connect()
+```
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Optional, Union
+from urllib.parse import ParseResult, parse_qs
+
+from dali import command, gear, memory
+from dali.driver.serial import DriverSerialBase
+from dali.memory.location import MemoryBank
+from dali.tests import fakes as dali_fakes
+from dali.driver import trace_logging  # noqa: F401
+
+_LOG = logging.getLogger("dali.driver")
+
+
+class DriverSerialDummy(DriverSerialBase):
+    uri_scheme = "dummy"
+    hardware_delay = 0.005
+
+    class DummyBank0(dali_fakes.FakeMemoryBank):
+        bank = memory.info.BANK_0
+        initial_contents = [
+            0x7F,
+            None,
+            0x00,  # Memory bank 0 is last accessible
+            0x01,
+            0x1F,
+            0x71,
+            0xF7,
+            0x6B,
+            0xB1,  # GTIN 1234567654321
+            0x03,
+            0x02,  # Firmware version 3.2
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0xAA,
+            0xBB,
+            0xCC,
+            0xFF,  # Serial number
+            0x02,
+            0x01,  # Hardware version 2.1
+            0x08,
+            0x08,  # Parts 101 and 102 version 2.0
+            0xFF,  # Part 103 not implemented
+            0x00,  # 0 logical control device units
+            0x01,  # 1 logical control gear unit
+            0x00,  # This is control gear unit index 0
+        ]
+
+    class DummyJalousieBank0(dali_fakes.FakeMemoryBank):
+        bank = MemoryBank(0, 0x10, has_lock=False)
+        initial_contents = [
+            0x7F,
+            None,
+            0x02,  # Memory bank 2 is last accessible
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,  # GTIN 0 (for some reason Lunatone don't support this)
+            0x02,
+            0x04,  # Firmware version 2.4
+            0xCC,
+            0xBB,
+            0xAA,
+            0x00,  # Serial number
+            0x01,  # Gear Unit Count
+            0x01,  # Gear Unit Index
+            0x00,
+            0x00,
+            0x02,
+            0x01,  # Hardware version 2.1
+            0x08,
+            0x01,  # The Jalousie uses DALI-1
+            0x00,
+        ]
+
+    class DummyJalousieBank2(dali_fakes.FakeMemoryBank):
+        bank = MemoryBank(2, 0x22, has_lock=False)
+        initial_contents = [
+            34,  # Length of memory bank
+            None,
+            None,
+            76,  # Seems like this is the Lunatone DALI-1 identifier
+            117,
+            110,
+            97,
+            116,
+            111,
+            110,
+            101,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            5,  # Specific part ID for Jalousie
+            39,
+            65,
+            52,
+            None,
+        ]
+
+    def __init__(self, *, uri: Union[str, ParseResult]):
+        """
+        The DriverSerialDummy class will 'magically' create pretend devices, based on the query
+        string passed in through the URI. These dummy devices won't physically exist, but do
+        provide a way of testing higher-level functions without needing physical hardware. Any
+        interactions that would be sent to hardware are instead written to a logfile, created
+        locally at the path provided in the URI.
+
+        :param uri: A special URI (either string or ParseResult object) which tells the dummy
+        driver where to save its logfile, and how many dummy devices to create.
+        URI format example: "dummy:///path/to/logfile?led=4&cover=2&relay=2"
+        """
+        super().__init__(uri)
+        uri = self.uri
+
+        self._log_path = uri.path
+        query = parse_qs(uri.query, strict_parsing=True)
+        self._num_leds = 0
+        try:
+            self._num_leds = int(query["led"][0])
+        except (IndexError, KeyError):
+            _LOG.info(f"URI query does not specify any LEDs: '{uri.query}'")
+        self._num_covers = 0
+        self._cover_addrs: set[int] = set()
+        try:
+            self._num_covers = int(query["cover"][0])
+        except (IndexError, KeyError):
+            _LOG.info(f"URI query does not specify any Covers: '{uri.query}'")
+        self._num_relays = 0
+        try:
+            self._num_relays = int(query["relay"][0])
+        except (IndexError, KeyError):
+            _LOG.info(f"URI query does not specify any Relays: '{uri.query}'")
+
+        _LOG.debug(f"Initialising dummy driver with logfile path '{self._log_path}'")
+        _LOG.info(
+            f"Dummy instances to be created: {self._num_leds} LEDs, {self._num_covers} covers, "
+            f"{self._num_relays} relays"
+        )
+
+        # Create dummy 'devices'. All are addressed sequentially.
+        self._dummy_bus = dali_fakes.Bus([])
+        new_address = 0
+        for _ in range(self._num_leds):
+            self._dummy_bus.gear.append(
+                dali_fakes.Gear(
+                    new_address,
+                    devicetypes=[6],
+                    memory_banks=(DriverSerialDummy.DummyBank0,),
+                )
+            )
+            # Force the LSB of the device serial number to equal the address
+            self._dummy_bus.gear[new_address].memory_banks[0].contents[18] = new_address
+            new_address += 1
+        for _ in range(self._num_covers):
+            new_cover = dali_fakes.Gear(
+                new_address,
+                devicetypes=[0],
+                memory_banks=(
+                    DriverSerialDummy.DummyJalousieBank0,
+                    DriverSerialDummy.DummyJalousieBank2,
+                ),
+            )
+            # Emulating a Lunatone Jalousie, which uses scenes to control movement up/down
+            new_cover.scenes[1] = 254
+            new_cover.scenes[3] = 253
+            # The serial number has a different address for DALI-1 (0x0E instead of 0x12)
+            new_cover.memory_banks[0].contents[0x0E] = new_address
+            self._dummy_bus.gear.append(new_cover)
+            # Keep track of which addresses belong to covers, for special handling
+            self._cover_addrs.add(new_address)
+            new_address += 1
+        for _ in range(self._num_relays):
+            self._dummy_bus.gear.append(
+                dali_fakes.Gear(
+                    new_address,
+                    devicetypes=[7],
+                    memory_banks=(DriverSerialDummy.DummyBank0,),
+                )
+            )
+            # Force the LSB of the device serial number to equal the address
+            self._dummy_bus.gear[new_address].memory_banks[0].contents[18] = new_address
+            new_address += 1
+
+        if new_address >= 64:
+            raise RuntimeError("Cannot have more than 64 devices on a DALI bus")
+
+    @staticmethod
+    def _get_date() -> str:
+        return datetime.now().isoformat()
+
+    def _set_level_off(self, addr: int):
+        _LOG.info(f"Turning off A{addr}")
+        self._dummy_bus.gear[addr].level = 0
+
+    async def connect(self) -> None:
+        if self.is_connected:
+            _LOG.warning("'connect()' called but dummy driver already connected")
+            return
+        # The dummy driver doesn't actually do any real communication, all we need to do is check
+        # that the path we've been given can be opened
+        with open(self._log_path, mode="wt", encoding="utf-8") as log_file:
+            log_file.write(
+                f"\n{self._get_date()} Starting new DriverSerialDummy instance\n"
+            )
+        # The file will be automatically closed after the write is done, it's not quite as efficient
+        # as it could be to open it each time, but it's a bit safer and ensures a clean write
+        self._connected.set()
+
+    async def send(
+        self, msg: command.Command, in_transaction: bool = False
+    ) -> Optional[command.Response]:
+        """
+        The 'send()' method for the DriverSerialDummy class doesn't actually communicate with
+        anything external - it just tries to imitate hardware, at a very basic level. For now,
+        all that is implemented is:
+        * Short addressing (i.e. referring to a dummy device directly by its address)
+        * Broadcast addressing
+        * Brightness/Power Level (can be set via DAPC, RecallMaxLevel, RecallMinLevel, Off)
+        * Device Type
+
+        :param msg: The DALI message to send
+        :param in_transaction: Flag whether or not this 'send()' call is part of a transaction
+        (i.e. if this call is coming from the 'run_sequence()' method). If the flag is set then
+        the lock will not be acquired before sending.
+        :return: If a command being sent expects a response, and the type is supported by
+        DriverSerialDummy, then it will be returned by the 'send()' call. If more than one command
+        generates a response then only the last response will be returned. Otherwise, None.
+        """
+        # Only send if the driver is connected
+        if not self.is_connected:
+            _LOG.critical(f"Cannot send, driver is not connected: {self}")
+            raise IOError("Cannot send, driver is not connected")
+
+        # If multiple responses are requested in a list of messages to send, only the last response
+        # will be returned
+        response = None
+
+        # "Send" each message, one at a time, and figure out what the dummy response should be
+        if not in_transaction:
+            await self.transaction_lock.acquire()
+        try:
+            with open(self._log_path, mode="at", encoding="utf-8") as log_file:
+                # Write the message to the log file, emulating sending it over a DALI bus
+                log_file.write(f"{self._get_date()} {msg}\n")
+                # Because writing to a log file is much faster than writing over RS232, there
+                # is a short delay here to make the dummy act a bit more like a real DALI device
+                await asyncio.sleep(DriverSerialDummy.hardware_delay)
+                # Get the response from the dummy bus
+                response = self._dummy_bus.send(msg)
+
+                # Special handling for a Lunatone Jalousie dummy device
+                if hasattr(msg, "destination"):
+                    if hasattr(msg.destination, "address"):
+                        if isinstance(msg, gear.general.GoToScene):
+                            dst = msg.destination.address
+                            if dst in self._cover_addrs:
+                                _LOG.info(f"Scheduling dummy call to turn off A{dst}")
+                                asyncio.get_running_loop().call_later(
+                                    delay=10.0,
+                                    callback=lambda: self._set_level_off(addr=dst),
+                                )
+
+        finally:
+            if not in_transaction:
+                self.transaction_lock.release()
+
+        return response
+
+    async def wait_dali_rx(self) -> command.Command:
+        raise RuntimeError("'wait_dali_rx()' is not implemented for DriverSerialDummy")

--- a/dali/tests/test_dummy.py
+++ b/dali/tests/test_dummy.py
@@ -1,0 +1,183 @@
+"""
+test_dummy.py - A pytest test suite for the 'dummy' serial driver class
+
+
+This file is part of python-dali.
+
+python-dali is free software: you can redistribute it and/or modify it under the terms of the GNU
+Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with this program.
+If not, see <https://www.gnu.org/licenses/>.
+"""
+import os.path
+from typing import NamedTuple
+
+import py
+import pytest
+
+from dali.driver.serial import DriverSerialBase, DriverLubaRs232, drivers_map
+from dali.tests.fakes_serial import DriverSerialDummy
+from dali import address, gear
+from dali.sequences import QueryDeviceTypes
+
+
+class DummyDriverFixtureParts(NamedTuple):
+    # The type hint for 'log' seems odd, but is correct - refer to this doc page
+    # https://docs.pytest.org/en/latest/reference/reference.html?highlight=tmpdir#tmpdir
+    log: py._path.local.LocalPath
+    uri: str
+    driver: DriverSerialDummy
+
+
+@pytest.fixture
+def make_dummy_driver(tmpdir):
+    """
+    A test fixture for creating an instance of a dummy driver
+    """
+
+    def _dummy_driver(
+        suffix: str = "0", led: int = 6, cover: int = 4, relay: int = 2
+    ) -> DummyDriverFixtureParts:
+        log = tmpdir.join(f"dummylog_{suffix}.txt")
+        uri = f"dummy://{log}?led={led}&cover={cover}&relay={relay}"
+        driver = DriverSerialDummy(uri=uri)
+
+        return DummyDriverFixtureParts(log=log, uri=uri, driver=driver)
+
+    return _dummy_driver
+
+
+@pytest.fixture
+def dummy_driver(make_dummy_driver) -> DummyDriverFixtureParts:
+    """
+    A test fixture that creates a basic instance of a test driver, using make_dummy_driver
+    """
+    return make_dummy_driver()
+
+
+def test_base_init_block():
+    """
+    Makes sure that the DriverSerialBase class cannot be initialised as a standalone object. It
+    needs to be used as a subclass.
+    """
+    with pytest.raises(RuntimeError):
+        DriverSerialBase(uri="")
+
+
+def test_drivers_map():
+    """
+    Tests the mapping from URI schemes to driver classes
+    """
+    drivers = drivers_map()
+    assert drivers["dummy"] == DriverSerialDummy
+    assert drivers["luba232"] == DriverLubaRs232
+
+
+def test_dummy_init_good(tmp_path):
+    """
+    Tests a dummy driver is initialised with the correct dummy devices
+    """
+    log = os.path.join(tmp_path, "dummylog.txt")
+    test_uri = f"dummy://{log}?led=2&cover=2&relay=4"
+    dummy_driver = DriverSerialDummy(uri=test_uri)
+
+    assert dummy_driver._num_leds == 2
+    assert dummy_driver._num_covers == 2
+    assert dummy_driver._num_relays == 4
+
+
+def test_dummy_init_bad_scheme(tmp_path):
+    """
+    Tests a dummy driver cannot be initialised with a bad URI scheme
+    """
+    log = os.path.join(tmp_path, "dummylog.txt")
+    test_uri = f"dmy://{log}?led=2&cover=2&relay=4"
+    with pytest.raises(TypeError):
+        DriverSerialDummy(uri=test_uri)
+
+
+def test_dummy_init_no_led(tmp_path):
+    """
+    Tests a dummy driver can be initialised without any dummy LEDs
+    """
+    log = os.path.join(tmp_path, "dummylog.txt")
+    test_uri = f"dummy://{log}logfile?cover=2&relay=4"
+    dummy_driver = DriverSerialDummy(uri=test_uri)
+
+    assert dummy_driver._num_leds == 0
+    assert dummy_driver._num_covers == 2
+    assert dummy_driver._num_relays == 4
+
+
+def test_dummy_init_no_cover(tmp_path):
+    """
+    Tests a dummy driver can be initialised without any dummy covers
+    """
+    log = os.path.join(tmp_path, "dummylog.txt")
+    test_uri = f"dummy://{log}?led=2&relay=4"
+    dummy_driver = DriverSerialDummy(uri=test_uri)
+
+    assert dummy_driver._num_leds == 2
+    assert dummy_driver._num_covers == 0
+    assert dummy_driver._num_relays == 4
+
+
+def test_dummy_init_no_relay(tmp_path):
+    """
+    Tests a dummy driver can be initialised without any dummy relays
+    """
+    log = os.path.join(tmp_path, "dummylog.txt")
+    test_uri = f"dummy://{log}?cover=2&led=4"
+    dummy_driver = DriverSerialDummy(uri=test_uri)
+
+    assert dummy_driver._num_leds == 4
+    assert dummy_driver._num_covers == 2
+    assert dummy_driver._num_relays == 0
+
+
+@pytest.mark.asyncio
+async def test_dummy_write_1(dummy_driver):
+    await dummy_driver.driver.connect()
+    await dummy_driver.driver.send(gear.general.DAPC(address.Short(1), 254))
+    assert "ArcPower(<address 1>,254)" in dummy_driver.log.read()
+
+
+@pytest.mark.asyncio
+async def test_dummy_write_2(dummy_driver):
+    await dummy_driver.driver.connect()
+    await dummy_driver.driver.send(gear.general.DAPC(address.Broadcast(), 127))
+    assert "ArcPower(<broadcast>,127)" in dummy_driver.log.read()
+
+
+@pytest.mark.asyncio
+async def test_dummy_write_3(dummy_driver):
+    await dummy_driver.driver.connect()
+    await dummy_driver.driver.send(gear.general.GoToScene(address.Short(1), 11))
+    assert "GoToScene(<address 1>,11)" in dummy_driver.log.read()
+
+
+@pytest.mark.asyncio
+async def test_dummy_sequence_device_types(dummy_driver):
+    await dummy_driver.driver.connect()
+    # The default of dummy_driver has 12 addressed control gears
+    for ad in range(11):
+        short = address.Short(ad)
+        dev_types = await dummy_driver.driver.run_sequence(QueryDeviceTypes(short))
+        # LEDs, DT6, are created first by the dummy driver
+        if ad in range(0, 5):
+            assert len(dev_types) == 1
+            assert dev_types[0] == 6
+        # Next is the custom Lunatone Jalousie cover, DT0
+        elif ad in range(6, 9):
+            assert len(dev_types) == 1
+            assert dev_types[0] == 0
+        # Finally the relays, DT7, are created
+        elif ad in range(10, 11):
+            assert len(dev_types) == 1
+            assert dev_types[0] == 7

--- a/examples/async-serial-luba.py
+++ b/examples/async-serial-luba.py
@@ -1,0 +1,87 @@
+"""
+async-serial-luba.py - Example showing the usage of the LUBA driver
+
+
+This file is part of python-dali.
+
+python-dali is free software: you can redistribute it and/or modify it under the terms of the GNU
+Lesser General Public License as published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along with this program.
+If not, see <https://www.gnu.org/licenses/>.
+
+
+
+This example shows how to use python-dali with a Lunatone RS232 LUBA protocol DALI interface.
+LUBA is a protocol defined by Lunatone for use in their devices, they publish the specification on
+their website: https://www.lunatone.com/wp-content/uploads/2021/04/LUBA_Protocol_EN.pdf
+
+It is assumed that an appropriate RS232 interface device is connected between the machine running
+python-dali and the Lunatone hardware, in writing this example an FTDI USB interface was used but
+any other compatible device will also work.
+"""
+import asyncio
+import logging
+
+from dali.address import Broadcast, Short
+from dali.driver.serial import DriverLubaRs232
+from dali.exceptions import DALISequenceError
+from dali.gear.general import DAPC, QueryControlGearPresent
+from dali.sequences import QueryDeviceTypes, QueryGroups
+
+# Define the path to the serial RS232 interface. The 'luba232' scheme tells the driver which
+# protocol to use - so far only the LUBA protocol is implemented, but others may be added in the
+# future
+URI = "luba232:/dev/ttyUSB0"
+
+
+async def listen_luba():
+    logger = logging.getLogger("dali")
+    log_handler = logging.StreamHandler()
+    log_formatter = logging.Formatter("%(asctime)s %(levelname)s:%(message)s")
+    log_formatter.default_msec_format = "%s.%03d"
+    log_handler.setFormatter(log_formatter)
+    logger.addHandler(log_handler)
+    logger.setLevel("INFO")
+
+    driver = DriverLubaRs232(uri=URI)
+    await driver.connect()
+
+    print("\nSending DAPC(254) to broadcast address")
+    await driver.send(DAPC(Broadcast(), 254))
+    await asyncio.sleep(1.5)
+    print("Sending DAPC(0) to broadcast address\n")
+    await driver.send(DAPC(Broadcast(), 0))
+
+    for ad in range(63):
+        short = Short(ad)
+        rsp = await driver.send(QueryControlGearPresent(short))
+        if rsp:
+            if rsp.value:
+                print(f"\nFound control gear A{ad}")
+                try:
+                    dts = await driver.run_sequence(
+                        QueryDeviceTypes(short), progress=print
+                    )
+                    print(f"  Device Types: {dts}")
+                except DALISequenceError:
+                    pass
+                try:
+                    gps = await driver.run_sequence(QueryGroups(short), progress=print)
+                    print(f"  Group Memberships: {list(gps) if gps else 'None'}")
+                except DALISequenceError:
+                    pass
+
+    print("\nListening for DALI commands on the bus...\n")
+    while True:
+        cmd = await driver.wait_dali_rx()
+        print(cmd)
+
+
+if __name__ == "__main__":
+    asyncio.get_event_loop().run_until_complete(listen_luba())

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+log_level = DEBUG
+asyncio_mode = strict


### PR DESCRIPTION
Lunatone make a series of DALI interface devices which communicate with a host over RS232 serial, using a protocol [defined by Lunatone](https://www.lunatone.com/wp-content/uploads/2021/04/LUBA_Protocol_EN.pdf) called 'LUBA'.

This pull request adds support into `python-dali` for LUBA interface devices, as briefly discussed in #102. The driver API largely follows the existing `hid` classes of drivers, including drop-in compatible support for sequences.

