### PR TITLE
Add DALI DT8 colour gear support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,8 @@ Library structure
 
   - ``gear`` - DALI control gear as defined in IEC 62386; stable
 
+    - ``colour`` - Commands from part 209 (Device Type 8)
+
     - ``emergency`` - Commands from part 202
 
     - ``general`` - Commands from part 102

--- a/dali/gear/__init__.py
+++ b/dali/gear/__init__.py
@@ -7,4 +7,5 @@ extensions and control gear specific features).
 import dali.gear.general
 import dali.gear.emergency
 import dali.gear.incandescent
+import dali.gear.colour
 import dali.gear.led  # noqa: F401

--- a/dali/gear/colour.py
+++ b/dali/gear/colour.py
@@ -1,0 +1,49 @@
+"""Commands and responses from IEC 62386 part 208."""
+
+from __future__ import unicode_literals
+from dali import command
+from dali.gear.general import _StandardCommand
+from enum import Enum
+
+class QueryValueVariables(Enum):
+    XCoordinate = 0
+    YCoordinate = 1
+    ColourTemperatureTC = 2
+    RedDimLevel = 9
+    GreenDimLevel = 10
+    BlueDimLevel = 11
+    WhiteDimLevel = 12
+    AmberDimLevel = 13
+    FreecolourDimLevel = 14
+    RGBWAFControl = 15
+
+    @property
+    def dtrVal(self) -> int:
+        return self.value
+
+
+class _ColourCommand(_StandardCommand):
+    _devicetype = 0x08
+
+class SetTemporaryXCoordinate(_ColourCommand):
+    _cmdval = 0xE0
+
+class SetTemporaryYCoordinate(_ColourCommand):
+    _cmdval = 0xE1
+
+class SetTemporaryRGBDimLevel(_ColourCommand):
+    _cmdval = 0xEB
+
+class SetTemporaryRGBWAFControl(_ColourCommand):
+    _cmdval = 0xED
+
+class Activate(_ColourCommand):
+    _cmdval = 0xE2
+
+class QueryGearFeatures(_ColourCommand):
+    _cmdval = 0xF7
+    _response = command.NumericResponse
+
+class QueryColourValue(_ColourCommand):
+    _cmdval = 0xFA
+    _response = command.NumericResponse

--- a/dali/gear/colour.py
+++ b/dali/gear/colour.py
@@ -17,6 +17,12 @@ class QueryColourValueVariables(Enum):
     AmberDimLevel = 13
     FreecolourDimLevel = 14
     RGBWAFControl = 15
+    ReportRedDimLevel = 233
+    ReportGreenDimLevel = 234
+    ReportBlueDimLevel = 235
+    ReportWhiteDimLevel = 236
+    ReportAmberDimLevel = 237
+    ReportFreecolourDimLevel = 238
 
     @property
     def dtrVal(self) -> int:
@@ -63,7 +69,7 @@ class QueryGearFeaturesStatusResponse(command.BitmapResponseBitDict):
 
 class QueryGearFeaturesStatus(_ColourCommand):
     _cmdval = 0xF7
-    _response = QueryGearFeaturesStatusResponse
+    response = QueryGearFeaturesStatusResponse
 
 
 class QueryColourStatusResponse(command.BitmapResponse):
@@ -78,12 +84,13 @@ class QueryColourStatusResponse(command.BitmapResponse):
     Bit 7: colour type RGBWAF active; 0 = NO
     """
     bits = ["xy-coord point out of range", "Tc temperature out of range", "Auto calibration running",
-            "type xy-coord active", "type Tc temperature active", "type primary N active", "type RGBWAF active"]
+            "Auto calibration successful", "type xy-coord active", "type Tc temperature active",
+            "type primary N active", "type RGBWAF active"]
 
 
 class QueryColourStatus(_ColourCommand):
     _cmdval = 0xF8
-    _response = QueryColourStatusResponse
+    response = QueryColourStatusResponse
 
 
 class QueryColourTypeFeaturesResponse(command.BitmapResponse):
@@ -99,9 +106,13 @@ class QueryColourTypeFeaturesResponse(command.BitmapResponse):
 
 class QueryColourTypeFeatures(_ColourCommand):
     _cmdval = 0xF9
-    _response = QueryColourTypeFeaturesResponse
+    response = QueryColourTypeFeaturesResponse
 
 
 class QueryColourValue(_ColourCommand):
+    """The answer depends on the DTR Value. (see QueryColourValueVariables enum)
+
+   Note: A control device should always use QueryActualLevel to update the reported colour setting before querying.
+    """
     _cmdval = 0xFA
-    _response = command.NumericResponse
+    response = command.NumericResponseMask

--- a/dali/gear/colour.py
+++ b/dali/gear/colour.py
@@ -5,7 +5,8 @@ from dali import command
 from dali.gear.general import _StandardCommand
 from enum import Enum
 
-class QueryValueVariables(Enum):
+
+class QueryColourValueVariables(Enum):
     XCoordinate = 0
     YCoordinate = 1
     ColourTemperatureTC = 2
@@ -25,24 +26,81 @@ class QueryValueVariables(Enum):
 class _ColourCommand(_StandardCommand):
     _devicetype = 0x08
 
+
 class SetTemporaryXCoordinate(_ColourCommand):
     _cmdval = 0xE0
+
 
 class SetTemporaryYCoordinate(_ColourCommand):
     _cmdval = 0xE1
 
+
 class SetTemporaryRGBDimLevel(_ColourCommand):
     _cmdval = 0xEB
+
+
+class SetTemporaryWAFDimLevel(_ColourCommand):
+    _cmdval = 0xEC
+
 
 class SetTemporaryRGBWAFControl(_ColourCommand):
     _cmdval = 0xED
 
+
 class Activate(_ColourCommand):
     _cmdval = 0xE2
 
-class QueryGearFeatures(_ColourCommand):
+
+class QueryGearFeaturesStatusResponse(command.BitmapResponseBitDict):
+    """Retrive gear feature/status info byte from the gear:
+    Bit 0: automatic ativation; 0 = NO
+    Bit 1..5: reserved
+    Bit 6: automatic callibration supported; 0 = NOT SUPPORTED
+    Bit 7: automatic callibration recovery supported; 0 = NOT SUPPORTED
+    """
+    bits = {0: "auto activation enabled", 6: "auto calibration supported", 7: "auto calibration recovery supported"}
+
+
+class QueryGearFeaturesStatus(_ColourCommand):
     _cmdval = 0xF7
-    _response = command.NumericResponse
+    _response = QueryGearFeaturesStatusResponse
+
+
+class QueryColourStatusResponse(command.BitmapResponse):
+    """Retrive gear colour status information:
+    Bit 0: xy-coordinate colour point out of range; 0 = NO
+    Bit 1: colour temperature Tc out of range; 0 = NO
+    Bit 2: auto calibration running; 0 = NO
+    Bit 3: auto calibration successful; 0 = NO
+    Bit 4: colour type xy-coordinate active; 0 = NO
+    Bit 5: colour type colour temperature Tc active; 0 = NO
+    Bit 6: colour type primary N active; 0 = NO
+    Bit 7: colour type RGBWAF active; 0 = NO
+    """
+    bits = ["xy-coord point out of range", "Tc temperature out of range", "Auto calibration running",
+            "type xy-coord active", "type Tc temperature active", "type primary N active", "type RGBWAF active"]
+
+
+class QueryColourStatus(_ColourCommand):
+    _cmdval = 0xF8
+    _response = QueryColourStatusResponse
+
+
+class QueryColourTypeFeaturesResponse(command.BitmapResponse):
+    """Retrieve gear supported colour type features:
+
+    Bit 0: xy-coordinate
+    Bit 1: colour temperature Tc
+    Bit 2: primary N
+    Bit 2: RGBWAF
+    """
+    bits = ["xy-coordinate", "colour temperature Tc", "primary N", "RGBWAF"]
+
+
+class QueryColourTypeFeatures(_ColourCommand):
+    _cmdval = 0xF9
+    _response = QueryColourTypeFeaturesResponse
+
 
 class QueryColourValue(_ColourCommand):
     _cmdval = 0xFA

--- a/dali/gear/colour.py
+++ b/dali/gear/colour.py
@@ -1,15 +1,30 @@
-"""Commands and responses from IEC 62386 part 208."""
+"""
+Commands and responses from IEC 62386 part 209, Device Type 8 Colour Control
+gear
+"""
+from __future__ import annotations
 
-from __future__ import unicode_literals
+from enum import IntEnum
+
 from dali import command
 from dali.gear.general import _StandardCommand
-from enum import Enum
 
 
-class QueryColourValueVariables(Enum):
+class QueryColourValueDTR(IntEnum):
+    """
+    Enum of all values from Part 209 Table 11 "Query Colour Value". See
+    QueryColourValue() for further information.
+    """
+
     XCoordinate = 0
     YCoordinate = 1
     ColourTemperatureTC = 2
+    PrimaryNDimLevel0 = 3
+    PrimaryNDimLevel1 = 4
+    PrimaryNDimLevel2 = 5
+    PrimaryNDimLevel3 = 6
+    PrimaryNDimLevel4 = 7
+    PrimaryNDimLevel5 = 8
     RedDimLevel = 9
     GreenDimLevel = 10
     BlueDimLevel = 11
@@ -17,102 +32,370 @@ class QueryColourValueVariables(Enum):
     AmberDimLevel = 13
     FreecolourDimLevel = 14
     RGBWAFControl = 15
+    XCoordinatePrimaryN0 = 64
+    YCoordinatePrimaryN0 = 65
+    TYPrimaryN0 = 66
+    XCoordinatePrimaryN1 = 67
+    YCoordinatePrimaryN1 = 68
+    TYPrimaryN1 = 69
+    XCoordinatePrimaryN2 = 70
+    YCoordinatePrimaryN2 = 71
+    TYPrimaryN2 = 72
+    XCoordinatePrimaryN3 = 73
+    YCoordinatePrimaryN3 = 74
+    TYPrimaryN3 = 75
+    XCoordinatePrimaryN4 = 76
+    YCoordinatePrimaryN4 = 77
+    TYPrimaryN4 = 78
+    XCoordinatePrimaryN5 = 79
+    YCoordinatePrimaryN5 = 80
+    TYPrimaryN5 = 81
+    NumberOfPrimaries = 82
+    ColourTemperatureTcCoolest = 128
+    ColourTemperatureTcPhysicalCoolest = 129
+    ColourTemperatureTcWarmest = 130
+    ColourTemperatureTcPhysicalWarmest = 131
+    TemporaryXCoordinate = 192
+    TemporaryYCoordinate = 193
+    TemporaryColourTemperature = 194
+    TemporaryPrimaryNDimLevel0 = 195
+    TemporaryPrimaryNDimLevel1 = 196
+    TemporaryPrimaryNDimLevel2 = 197
+    TemporaryPrimaryNDimLevel3 = 198
+    TemporaryPrimaryNDimLevel4 = 199
+    TemporaryPrimaryNDimLevel5 = 200
+    TemporaryRedDimLevel = 201
+    TemporaryGreenDimLevel = 202
+    TemporaryBlueDimLevel = 203
+    TemporaryWhiteDimLevel = 204
+    TemporaryAmberDimLevel = 205
+    TemporaryFreecolourDimLevel = 206
+    TemporaryRgbwafControl = 207
+    TemporaryColourType = 208
+    ReportXCoordinate = 224
+    ReportYCoordinate = 225
+    ReportColourTemperatureTc = 226
+    ReportPrimaryNDimLevel0 = 227
+    ReportPrimaryNDimLevel1 = 228
+    ReportPrimaryNDimLevel2 = 229
+    ReportPrimaryNDimLevel3 = 230
+    ReportPrimaryNDimLevel4 = 231
+    ReportPrimaryNDimLevel5 = 232
     ReportRedDimLevel = 233
     ReportGreenDimLevel = 234
     ReportBlueDimLevel = 235
     ReportWhiteDimLevel = 236
     ReportAmberDimLevel = 237
     ReportFreecolourDimLevel = 238
-
-    @property
-    def dtrVal(self) -> int:
-        return self.value
+    ReportRgbwafControl = 239
+    ReportColourType = 240
 
 
 class _ColourCommand(_StandardCommand):
-    _devicetype = 0x08
+    devicetype = 0x08
 
 
 class SetTemporaryXCoordinate(_ColourCommand):
-    _cmdval = 0xE0
+    uses_dtr0 = True
+    uses_dtr1 = True
+    _cmdval = 224
 
 
 class SetTemporaryYCoordinate(_ColourCommand):
-    _cmdval = 0xE1
-
-
-class SetTemporaryRGBDimLevel(_ColourCommand):
-    _cmdval = 0xEB
-
-
-class SetTemporaryWAFDimLevel(_ColourCommand):
-    _cmdval = 0xEC
-
-
-class SetTemporaryRGBWAFControl(_ColourCommand):
-    _cmdval = 0xED
+    uses_dtr0 = True
+    uses_dtr1 = True
+    _cmdval = 225
 
 
 class Activate(_ColourCommand):
-    _cmdval = 0xE2
+    _cmdval = 226
 
 
-class QueryGearFeaturesStatusResponse(command.BitmapResponseBitDict):
-    """Retrive gear feature/status info byte from the gear:
-    Bit 0: automatic ativation; 0 = NO
-    Bit 1..5: reserved
-    Bit 6: automatic callibration supported; 0 = NOT SUPPORTED
-    Bit 7: automatic callibration recovery supported; 0 = NOT SUPPORTED
+class XCoordinateStepUp(_ColourCommand):
+    _cmdval = 227
+
+
+class XCoordinateStepDown(_ColourCommand):
+    _cmdval = 228
+
+
+class YCoordinateStepUp(_ColourCommand):
+    _cmdval = 229
+
+
+class YCoordinateStepDown(_ColourCommand):
+    _cmdval = 230
+
+
+class SetTemporaryColourTemperature(_ColourCommand):
+    uses_dtr0 = True
+    uses_dtr1 = True
+    _cmdval = 231
+
+
+class ColourTemperatureTcStepCooler(_ColourCommand):
+    _cmdval = 232
+
+
+class ColourTemperatureTcStepWarmer(_ColourCommand):
+    _cmdval = 233
+
+
+class SetTemporaryPrimaryNDimLevel(_ColourCommand):
+    uses_dtr0 = True
+    uses_dtr1 = True
+    uses_dtr2 = True
+    _cmdval = 234
+
+
+class SetTemporaryRGBDimLevel(_ColourCommand):
+    uses_dtr0 = True
+    uses_dtr1 = True
+    uses_dtr2 = True
+    _cmdval = 235
+
+
+class SetTemporaryWAFDimLevel(_ColourCommand):
+    uses_dtr0 = True
+    uses_dtr1 = True
+    uses_dtr2 = True
+    _cmdval = 236
+
+
+class SetTemporaryRGBWAFControl(_ColourCommand):
+    uses_dtr0 = True
+    _cmdval = 237
+
+
+class CopyReportToTemporary(_ColourCommand):
+    _cmdval = 238
+
+
+class StoreTYPrimaryN(_ColourCommand):
+    uses_dtr0 = True
+    uses_dtr1 = True
+    uses_dtr2 = True
+    _cmdval = 240
+
+
+class StoreXYCoordinatePrimaryN(_ColourCommand):
+    uses_dtr2 = True
+    _cmdval = 241
+
+
+class StoreColourTemperatureTcLimit(_ColourCommand):
+    uses_dtr0 = True
+    uses_dtr1 = True
+    uses_dtr2 = True
+    _cmdval = 242
+
+
+class StoreGearFeaturesStatus(_ColourCommand):
+    uses_dtr0 = True
+    _cmdval = 243
+
+
+class AssignColourToLinkedChannel(_ColourCommand):
+    uses_dtr0 = True
+    _cmdval = 245
+
+
+class StartAutoCalibration(_ColourCommand):
+    _cmdval = 246
+
+
+class QueryGearFeaturesStatusResponse(command.BitmapResponse):
     """
-    bits = {0: "auto activation enabled", 6: "auto calibration supported", 7: "auto calibration recovery supported"}
+    Gear Features Status for a DT8 control gear, as defined in Part 209
+    section 11.3.4.3, Command 247 "QUERY GEAR FEATURES/STATUS".
+    """
+
+    bits = [
+        "auto activation enabled",
+        "reserved 1",
+        "reserved 2",
+        "reserved 3",
+        "reserved 4",
+        "reserved 5",
+        "auto calibration supported",
+        "auto calibration recovery supported",
+    ]
 
 
 class QueryGearFeaturesStatus(_ColourCommand):
-    _cmdval = 0xF7
+    _cmdval = 247
     response = QueryGearFeaturesStatusResponse
 
 
 class QueryColourStatusResponse(command.BitmapResponse):
-    """Retrive gear colour status information:
-    Bit 0: xy-coordinate colour point out of range; 0 = NO
-    Bit 1: colour temperature Tc out of range; 0 = NO
-    Bit 2: auto calibration running; 0 = NO
-    Bit 3: auto calibration successful; 0 = NO
-    Bit 4: colour type xy-coordinate active; 0 = NO
-    Bit 5: colour type colour temperature Tc active; 0 = NO
-    Bit 6: colour type primary N active; 0 = NO
-    Bit 7: colour type RGBWAF active; 0 = NO
     """
-    bits = ["xy-coord point out of range", "Tc temperature out of range", "Auto calibration running",
-            "Auto calibration successful", "type xy-coord active", "type Tc temperature active",
-            "type primary N active", "type RGBWAF active"]
+    Colour Status for a DT8 control gear, as defined in Part 209 section
+    11.3.4.3, Command 248 "QUERY COLOUR STATUS".
+    """
+
+    bits = [
+        "xy colour point out of range",
+        "colour temperature Tc out of range",
+        "auto calibration running",
+        "auto calibration successful",
+        "colour type xy active",
+        "colour type colour temperature Tc active",
+        "colour type primary N active",
+        "colour type RGBWAF active",
+    ]
 
 
 class QueryColourStatus(_ColourCommand):
-    _cmdval = 0xF8
+    _cmdval = 248
     response = QueryColourStatusResponse
 
 
 class QueryColourTypeFeaturesResponse(command.BitmapResponse):
-    """Retrieve gear supported colour type features:
-
-    Bit 0: xy-coordinate
-    Bit 1: colour temperature Tc
-    Bit 2: primary N
-    Bit 2: RGBWAF
     """
-    bits = ["xy-coordinate", "colour temperature Tc", "primary N", "RGBWAF"]
+    Colour Type Features for a DT8 control gear, as defined in Part 209
+    section 11.3.4.3, Command 249 "QUERY COLOUR TYPE FEATURES".
+    """
+
+    bits = [
+        "xy capable",
+        "Tc capable",
+        "primary N bit 0",
+        "primary N bit 1",
+        "primary N bit 2",
+        "RGBWAF channels bit 0",
+        "RGBWAF channels bit 1",
+        "RGBWAF channels bit 2",
+    ]
+
+    @property
+    def primary_n(self) -> int:
+        """
+        Returns the number of primaries supported by the control gear
+        """
+        count = self.primary_N_bit_2 << 2
+        count += self.primary_N_bit_1 << 1
+        count += self.primary_N_bit_0
+        return count
+
+    @property
+    def RGBWAF_channels(self) -> int:
+        """
+        Returns the number of RGBWAF channels supported by the control gear
+        """
+        count = self.RGBWAF_channels_bit_2 << 2
+        count += self.RGBWAF_channels_bit_1 << 1
+        count += self.RGBWAF_channels_bit_0
+        return count
 
 
 class QueryColourTypeFeatures(_ColourCommand):
-    _cmdval = 0xF9
+    _cmdval = 249
     response = QueryColourTypeFeaturesResponse
 
 
 class QueryColourValue(_ColourCommand):
-    """The answer depends on the DTR Value. (see QueryColourValueVariables enum)
-
-   Note: A control device should always use QueryActualLevel to update the reported colour setting before querying.
     """
-    _cmdval = 0xFA
+    The answer to QueryColourValue depends on the DTR Value. (see
+    QueryColourValueDTR enum). Most responses involve a 16-bit number,
+    in such cases the reponse is the MSB and LSB is loaded into DTR0. See
+    Part 209 Table 11 and Table 15 for full details.
+
+    Note: A control device should always use QueryActualLevel to update the
+    reported colour setting before querying.
+    """
+
+    _cmdval = 250
     response = command.NumericResponseMask
+
+
+class QueryRBGWAFControlResponse(command.BitmapResponse):
+    bits = [
+        "channel 0 red",
+        "channel 1 green",
+        "channel 2 blue",
+        "channel 3 white",
+        "channel 4 amber",
+        "channel 5 freecolour",
+        "control type bit 0",
+        "control type bit 1",
+    ]
+
+    @property
+    def control_type(self) -> str:
+        """
+        Returns the "Control Type" for the RGBWAF function, one of:
+        * channel control
+        * colour control
+        * normalised colour control
+        """
+        count = self.control_type_bit_1 << 1
+        count += self.control_type_bit_0
+        if count == 0:
+            return "channel control"
+        elif count == 1:
+            return "colour control"
+        elif count == 2:
+            return "normalised colour control"
+        else:
+            return "(error)"
+
+
+class QueryRBGWAFControl(_ColourCommand):
+    _cmdval = 251
+    response = QueryRBGWAFControlResponse
+
+
+class AssignedColour(IntEnum):
+    """
+    Enum of all values from Part 209 Table 12 "Query Assigned Colour"
+    """
+
+    not_assigned = 0
+    red = 1
+    green = 2
+    blue = 3
+    white = 4
+    amber = 5
+    freecolour = 6
+
+
+class QueryAssignedColourResponse(command.EnumResponse):
+    """
+    Assigned colour for a given channel (as specified in DTR0). Refer to Part
+    209 section 11.3.4.3, Command 252 "QUERY ASSIGNED COLOUR".
+
+    Note that a response may indicate an assigned channel, or could also be
+    "MASK" if the queried channel is not supported or is invalid.
+    """
+
+    enumerator = AssignedColour
+
+    @property
+    def value(self):
+        if self.raw_value is None:
+            return None
+        _value = self.raw_value.as_integer
+        if 6 < _value < 255:
+            return "(error)"
+        elif _value == 255:
+            return "MASK"
+        else:
+            return super().value
+
+
+class QueryAssignedColour(_ColourCommand):
+    """
+    The answer shall be the number of the assigned colour (see AssignedColour
+    class) of the output channel given by the DTR. The DTR shall contain one of
+    the channel numbers 0 to 5. For all other values of DTR and unsupported
+    channel numbers the answer shall be “MASK”.
+    """
+
+    uses_dtr0 = True
+    _cmdval = 252
+    response = QueryAssignedColourResponse
+
+
+class QueryExtendedVersionNumber(_ColourCommand):
+    _cmdval = 255
+    response = command.NumericResponse

--- a/dali/gear/sequences.py
+++ b/dali/gear/sequences.py
@@ -1,0 +1,86 @@
+"""
+Sequence for simplifying certain interactions with 16-bit DALI gear
+"""
+from __future__ import annotations
+
+from typing import Generator, Optional
+
+from dali import command
+from dali.address import GearAddress, GearShort
+from dali.gear.colour import (
+    Activate,
+    QueryColourValue,
+    QueryColourValueDTR,
+    SetTemporaryColourTemperature,
+)
+from dali.gear.general import DTR0, DTR1, QueryActualLevel, QueryContentDTR0
+
+
+def SetDT8ColourValueTc(
+    address: GearAddress,
+    tc_mired: int,
+) -> Generator[command.Command, Optional[command.Response], None]:
+    """
+    A generator sequence set query the Colour Temperature of a DT8 control
+    gear. Note that this sequence assumes that the address being targeted
+    supports DT8 Tc control, it will not check this before sending commands.
+
+    :param address: GearAddress (i.e. short, group, broadcast) address to set
+    :param tc_mired: An int of the colour temperature to set, in mired
+    :return: None
+    """
+    # Although the proper types are expected, ints are common enough for
+    # addresses and their meaning is unambiguous in this context
+    if isinstance(address, int):
+        address = GearShort(address)
+
+    tc_bytes = tc_mired.to_bytes(length=2, byteorder="little")
+    yield DTR0(tc_bytes[0])
+    yield DTR1(tc_bytes[1])
+    yield SetTemporaryColourTemperature(address)
+    yield Activate(address)
+
+
+def QueryDT8ColourValue(
+    address: GearShort,
+    query: QueryColourValueDTR,
+) -> Generator[command.Command, Optional[command.Response], Optional[int]]:
+    """
+    A generator sequence to query the Colour Value of a DT8 control gear,
+    from the list of numerous options in QueryColourValueDTR.
+
+    Note that this sequence assumes that the address being targeted supports
+    the selected colour control method, it will not check this before sending
+    commands. The return value will be an int (or None), assembled from the
+    two bytes response.
+
+    :param address: GearShort address to query
+    :param query: specific option from QueryColourValueDTR to send as the query
+    :return: The answer to the query as an int, or None if no answer
+    """
+    # Although the proper types are expected, ints are common enough for
+    # addresses and their meaning is unambiguous in this context
+    if isinstance(address, int):
+        address = GearShort(address)
+
+    if not isinstance(query, QueryColourValueDTR):
+        raise TypeError(
+            "'query' must be a value from QueryColourValueDTR enumerator"
+        )
+
+    yield QueryActualLevel(address)
+    yield DTR0(query.value)
+    msb = yield QueryColourValue(address)
+    lsb = yield QueryContentDTR0(address)
+    col_val = None
+    if (
+        isinstance(msb, command.NumericResponseMask)
+        and isinstance(lsb, command.NumericResponse)
+        and isinstance(msb.value, int)
+    ):
+        try:
+            col_val = int.from_bytes((lsb.value, msb.value), "little")
+        except (TypeError, ValueError):
+            col_val = None
+
+    return col_val

--- a/dali/tests/fakes_serial.py
+++ b/dali/tests/fakes_serial.py
@@ -217,7 +217,7 @@ class DriverSerialDummy(DriverSerialBase):
             self._dummy_bus.gear.append(
                 dali_fakes.Gear(
                     new_ad,
-                    devicetypes=[6],
+                    devicetypes=[8],
                     memory_banks=(DriverSerialDummy.DummyBank0,),
                 )
             )

--- a/dali/tests/test_colour.py
+++ b/dali/tests/test_colour.py
@@ -1,0 +1,69 @@
+import pytest  # noqa
+
+from dali.frame import BackwardFrame
+from dali.gear.colour import (
+    AssignedColour,
+    QueryAssignedColourResponse,
+    QueryColourTypeFeaturesResponse,
+    QueryRBGWAFControlResponse,
+)
+
+
+def test_colour_type_features_properties_decoding():
+    rsp = QueryColourTypeFeaturesResponse(BackwardFrame(0b10101010))
+
+    # These properties are common for any BitmapResponse
+    assert rsp.xy_capable == 0
+    assert rsp.Tc_capable == 1
+    assert rsp.primary_N_bit_0 == 0
+    assert rsp.primary_N_bit_1 == 1
+    assert rsp.primary_N_bit_2 == 0
+    assert rsp.RGBWAF_channels_bit_0 == 1
+    assert rsp.RGBWAF_channels_bit_1 == 0
+    assert rsp.RGBWAF_channels_bit_2 == 1
+
+    # These properties are special for QueryColourTypeFeaturesResponse
+    assert rsp.primary_n == 2
+    assert rsp.RGBWAF_channels == 5
+
+
+def test_query_assigned_colour_decoding():
+    rsp = QueryAssignedColourResponse(BackwardFrame(0b00000000))
+    assert rsp.value == AssignedColour.not_assigned
+    rsp = QueryAssignedColourResponse(BackwardFrame(0b00000001))
+    assert rsp.value == AssignedColour.red
+    rsp = QueryAssignedColourResponse(BackwardFrame(0b00000010))
+    assert rsp.value == AssignedColour.green
+    rsp = QueryAssignedColourResponse(BackwardFrame(0b00000011))
+    assert rsp.value == AssignedColour.blue
+    rsp = QueryAssignedColourResponse(BackwardFrame(0b00000100))
+    assert rsp.value == AssignedColour.white
+    rsp = QueryAssignedColourResponse(BackwardFrame(0b00000101))
+    assert rsp.value == AssignedColour.amber
+    rsp = QueryAssignedColourResponse(BackwardFrame(0b00000110))
+    assert rsp.value == AssignedColour.freecolour
+    rsp = QueryAssignedColourResponse(BackwardFrame(7))
+    assert rsp.value == "(error)"
+    rsp = QueryAssignedColourResponse(BackwardFrame(254))
+    assert rsp.value == "(error)"
+    rsp = QueryAssignedColourResponse(BackwardFrame(255))
+    assert rsp.value == "MASK"
+
+
+def test_query_rgbwaf_control_decoding():
+    rsp = QueryRBGWAFControlResponse(BackwardFrame(0b00000000))
+    assert not rsp.channel_0_red
+    assert rsp.control_type == "channel control"
+
+    rsp = QueryRBGWAFControlResponse(BackwardFrame(0b10000001))
+    assert rsp.channel_0_red
+    assert rsp.control_type == "normalised colour control"
+
+    rsp = QueryRBGWAFControlResponse(BackwardFrame(0b01000101))
+    assert rsp.channel_0_red
+    assert not rsp.channel_1_green
+    assert rsp.channel_2_blue
+    assert rsp.control_type == "colour control"
+
+    rsp = QueryRBGWAFControlResponse(BackwardFrame(0b11000000))
+    assert rsp.control_type == "(error)"

--- a/dali/tests/test_dummy.py
+++ b/dali/tests/test_dummy.py
@@ -4,16 +4,18 @@ test_dummy.py - A pytest test suite for the 'dummy' serial driver class
 
 This file is part of python-dali.
 
-python-dali is free software: you can redistribute it and/or modify it under the terms of the GNU
-Lesser General Public License as published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
+python-dali is free software: you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option) any
+later version.
 
-This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
-even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-Lesser General Public License for more details.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+details.
 
-You should have received a copy of the GNU Lesser General Public License along with this program.
-If not, see <https://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
 """
 import os.path
 from typing import NamedTuple
@@ -28,7 +30,8 @@ from dali.sequences import QueryDeviceTypes
 
 
 class DummyDriverFixtureParts(NamedTuple):
-    # The type hint for 'log' seems odd, but is correct - refer to this doc page
+    # The type hint for 'log' seems odd, but is correct - refer to this doc
+    # page:
     # https://docs.pytest.org/en/latest/reference/reference.html?highlight=tmpdir#tmpdir
     log: py._path.local.LocalPath
     uri: str
@@ -56,15 +59,16 @@ def make_dummy_driver(tmpdir):
 @pytest.fixture
 def dummy_driver(make_dummy_driver) -> DummyDriverFixtureParts:
     """
-    A test fixture that creates a basic instance of a test driver, using make_dummy_driver
+    A test fixture that creates a basic instance of a test driver,
+    using make_dummy_driver
     """
     return make_dummy_driver()
 
 
 def test_base_init_block():
     """
-    Makes sure that the DriverSerialBase class cannot be initialised as a standalone object. It
-    needs to be used as a subclass.
+    Makes sure that the DriverSerialBase class cannot be initialised as a
+    standalone object. It needs to be used as a subclass.
     """
     with pytest.raises(RuntimeError):
         DriverSerialBase(uri="")
@@ -151,14 +155,18 @@ async def test_dummy_write_1(dummy_driver):
 @pytest.mark.asyncio
 async def test_dummy_write_2(dummy_driver):
     await dummy_driver.driver.connect()
-    await dummy_driver.driver.send(gear.general.DAPC(address.GearBroadcast(), 127))
+    await dummy_driver.driver.send(
+        gear.general.DAPC(address.GearBroadcast(), 127)
+    )
     assert "ArcPower(<broadcast (control gear)>,127)" in dummy_driver.log.read()
 
 
 @pytest.mark.asyncio
 async def test_dummy_write_3(dummy_driver):
     await dummy_driver.driver.connect()
-    await dummy_driver.driver.send(gear.general.GoToScene(address.GearShort(1), 11))
+    await dummy_driver.driver.send(
+        gear.general.GoToScene(address.GearShort(1), 11)
+    )
     assert "GoToScene(<address (control gear) 1>,11)" in dummy_driver.log.read()
 
 
@@ -168,11 +176,13 @@ async def test_dummy_sequence_device_types(dummy_driver):
     # The default of dummy_driver has 12 addressed control gears
     for ad in range(11):
         short = address.GearShort(ad)
-        dev_types = await dummy_driver.driver.run_sequence(QueryDeviceTypes(short))
-        # LEDs, DT6, are created first by the dummy driver
+        dev_types = await dummy_driver.driver.run_sequence(
+            QueryDeviceTypes(short)
+        )
+        # Colour Temperature LEDs, DT8, are created first by the dummy driver
         if ad in range(0, 5):
             assert len(dev_types) == 1
-            assert dev_types[0] == 6
+            assert dev_types[0] == 8
         # Next is the custom Lunatone Jalousie cover, DT0
         elif ad in range(6, 9):
             assert len(dev_types) == 1

--- a/dali/tests/test_fakes.py
+++ b/dali/tests/test_fakes.py
@@ -1,15 +1,17 @@
 import unittest
 
 from dali.tests import fakes
-from dali import address, command, gear, device
-from dali.address import DeviceShort, GearShort, InstanceNumber
+from dali import command, gear, device
+from dali.address import DeviceShort, GearShort, GearBroadcast, InstanceNumber
+from dali.gear.colour import QueryColourValueDTR
+from dali.gear.sequences import SetDT8ColourValueTc, QueryDT8ColourValue
 
 
 class TestFakeGear(unittest.TestCase):
     def setUp(self):
         """
-        Creates four fake control gears, with addresses 0 to 3. Also has a control
-        device, just there to make sure it stays silent.
+        Creates four fake control gears, with addresses 0 to 3. Also has a
+        control device, just there to make sure it stays silent.
         """
         self.bus = fakes.Bus(
             [
@@ -17,143 +19,191 @@ class TestFakeGear(unittest.TestCase):
                 fakes.Gear(GearShort(1), memory_banks=(fakes.FakeBank0,)),
                 fakes.Gear(GearShort(2), memory_banks=(fakes.FakeBank0,)),
                 fakes.Gear(GearShort(3), memory_banks=(fakes.FakeBank0,)),
+                fakes.Gear(
+                    GearShort(4),
+                    devicetypes=[8],
+                    memory_banks=(fakes.FakeBank0,),
+                ),
                 fakes.Device(DeviceShort(0), memory_banks=(fakes.FakeBank0,)),
             ]
         )
 
     def test_fake_gear_dapc(self):
         # The level should initialise to 0
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 0)
-        self.bus.send(gear.general.DAPC(address.Short(0), 128))
+        self.bus.send(gear.general.DAPC(GearShort(0), 128))
         # After DAPC the level should be 128
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 128)
 
     def test_fake_gear_recall_max(self):
         # The level should initialise to 0
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 0)
-        self.bus.send(gear.general.RecallMaxLevel(address.Short(0)))
+        self.bus.send(gear.general.RecallMaxLevel(GearShort(0)))
         # After RecallMaxLevel the level should be 254
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 254)
 
     def test_fake_gear_recall_min(self):
         # The level should initialise to 0
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(1)))
         self.assertEqual(resp.value, 0)
-        self.bus.send(gear.general.RecallMinLevel(address.Short(1)))
+        self.bus.send(gear.general.RecallMinLevel(GearShort(1)))
         # After RecallMaxLevel the level should be 1
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(1)))
         self.assertEqual(resp.value, 1)
 
     def test_fake_gear_set_min(self):
         # Start with a level of 12
-        self.bus.send(gear.general.DAPC(address.Short(0), 12))
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.bus.send(gear.general.DAPC(GearShort(0), 12))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 12)
         # Set minimum level to 22
         self.bus.send(gear.general.DTR0(22))
-        self.bus.send(gear.general.SetMinLevel(address.Short(0)))
+        self.bus.send(gear.general.SetMinLevel(GearShort(0)))
         # After SetMinLevel the level should be 22
-        resp = self.bus.send(gear.general.QueryMinLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryMinLevel(GearShort(0)))
         self.assertEqual(resp.value, 22)
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 22)
         # Level should not go below 22
-        self.bus.send(gear.general.DAPC(address.Short(0), 12))
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.bus.send(gear.general.DAPC(GearShort(0), 12))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 22)
 
     def test_fake_gear_set_max(self):
         # Start with a level of 228
-        self.bus.send(gear.general.DAPC(address.Short(1), 228))
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        self.bus.send(gear.general.DAPC(GearShort(1), 228))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(1)))
         self.assertEqual(resp.value, 228)
         # Set maximum to 191
         self.bus.send(gear.general.DTR0(191))
-        self.bus.send(gear.general.SetMaxLevel(address.Short(1)))
+        self.bus.send(gear.general.SetMaxLevel(GearShort(1)))
         # After SetMaxLevel the level should be 191
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(1)))
         self.assertEqual(resp.value, 191)
-        resp = self.bus.send(gear.general.QueryMaxLevel(address.Short(1)))
+        resp = self.bus.send(gear.general.QueryMaxLevel(GearShort(1)))
         self.assertEqual(resp.value, 191)
         # Level should not go above 191
-        self.bus.send(gear.general.DAPC(address.Short(1), 228))
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        self.bus.send(gear.general.DAPC(GearShort(1), 228))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(1)))
         self.assertEqual(resp.value, 191)
 
     def test_fake_gear_set_min_above_max(self):
         self.bus.send(gear.general.DTR0(188))
-        self.bus.send(gear.general.SetMaxLevel(address.Short(0)))
-        resp = self.bus.send(gear.general.QueryMinLevel(address.Short(0)))
+        self.bus.send(gear.general.SetMaxLevel(GearShort(0)))
+        resp = self.bus.send(gear.general.QueryMinLevel(GearShort(0)))
         self.assertEqual(resp.value, 1)
-        # Trying to set the minimum to larger than the maximum should result in the
-        # minimum being set the same as the maximum
+        # Trying to set the minimum to larger than the maximum should result
+        # in the minimum being set the same as the maximum
         self.bus.send(gear.general.DTR0(200))
-        self.bus.send(gear.general.SetMinLevel(address.Short(0)))
-        resp = self.bus.send(gear.general.QueryMinLevel(address.Short(0)))
+        self.bus.send(gear.general.SetMinLevel(GearShort(0)))
+        resp = self.bus.send(gear.general.QueryMinLevel(GearShort(0)))
         self.assertEqual(resp.value, 188)
 
     def test_fake_gear_set_max_below_min(self):
         self.bus.send(gear.general.DTR0(188))
-        self.bus.send(gear.general.SetMinLevel(address.Short(0)))
-        # Trying to set the maximum to less than the minimum should result in the
-        # maximum being set the same as the minimum
+        self.bus.send(gear.general.SetMinLevel(GearShort(0)))
+        # Trying to set the maximum to less than the minimum should result in
+        # the maximum being set the same as the minimum
         self.bus.send(gear.general.DTR0(127))
-        self.bus.send(gear.general.SetMaxLevel(address.Short(0)))
-        resp = self.bus.send(gear.general.QueryMaxLevel(address.Short(0)))
+        self.bus.send(gear.general.SetMaxLevel(GearShort(0)))
+        resp = self.bus.send(gear.general.QueryMaxLevel(GearShort(0)))
         self.assertEqual(resp.value, 188)
 
     def test_fake_gear_set_scene(self):
         # Initially all scenes are MASK
-        resp = self.bus.send(gear.general.QuerySceneLevel(address.Short(0), 0))
+        resp = self.bus.send(gear.general.QuerySceneLevel(GearShort(0), 0))
         self.assertEqual(resp.value, "MASK")
         # Set some scene values
         self.bus.send(gear.general.DTR0(132))
-        self.bus.send(gear.general.SetScene(address.Short(0), 0))
+        self.bus.send(gear.general.SetScene(GearShort(0), 0))
         self.bus.send(gear.general.DTR0(143))
-        self.bus.send(gear.general.SetScene(address.Short(1), 0))
+        self.bus.send(gear.general.SetScene(GearShort(1), 0))
         self.bus.send(gear.general.DTR0(154))
-        self.bus.send(gear.general.SetScene(address.Short(2), 0))
+        self.bus.send(gear.general.SetScene(GearShort(2), 0))
         self.bus.send(gear.general.DTR0(165))
-        self.bus.send(gear.general.SetScene(address.Short(3), 0))
+        self.bus.send(gear.general.SetScene(GearShort(3), 0))
         # Outputs should be off
         for ad in range(0, 4):
-            resp = self.bus.send(gear.general.QueryActualLevel(address.Short(ad)))
+            resp = self.bus.send(gear.general.QueryActualLevel(GearShort(ad)))
             self.assertEqual(resp.value, 0)
         # Activate the scene via broadcast
-        self.bus.send(gear.general.GoToScene(address.Broadcast(), 0))
+        self.bus.send(gear.general.GoToScene(GearBroadcast(), 0))
         # Outputs should be on now
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 132)
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(1)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(1)))
         self.assertEqual(resp.value, 143)
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(2)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(2)))
         self.assertEqual(resp.value, 154)
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(3)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(3)))
         self.assertEqual(resp.value, 165)
 
     def test_fake_gear_set_off(self):
         # Set a higher minimum value
         self.bus.send(gear.general.DTR0(22))
-        self.bus.send(gear.general.SetMinLevel(address.Short(0)))
-        self.bus.send(gear.general.DAPC(address.Short(0), 10))
+        self.bus.send(gear.general.SetMinLevel(GearShort(0)))
+        self.bus.send(gear.general.DAPC(GearShort(0), 10))
         # Ensure minimum level
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 22)
         # Ensure DAPC of 0 still works
-        self.bus.send(gear.general.DAPC(address.Short(0), 0))
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.bus.send(gear.general.DAPC(GearShort(0), 0))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 0)
         # Ensure Off works
-        self.bus.send(gear.general.DAPC(address.Short(0), 10))
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.bus.send(gear.general.DAPC(GearShort(0), 10))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 22)
-        self.bus.send(gear.general.Off(address.Short(0)))
-        resp = self.bus.send(gear.general.QueryActualLevel(address.Short(0)))
+        self.bus.send(gear.general.Off(GearShort(0)))
+        resp = self.bus.send(gear.general.QueryActualLevel(GearShort(0)))
         self.assertEqual(resp.value, 0)
+
+    def test_fake_gear_dt8_extended_version(self):
+        # Address 4 is a DT8 gear, it should respond
+        resp = self.bus.send(
+            gear.colour.QueryExtendedVersionNumber(GearShort(4))
+        )
+        self.assertIsInstance(resp, command.NumericResponse)
+        self.assertEqual(resp.value, 2)
+        # Address 0 is not, it should ignore this command
+        resp = self.bus.send(
+            gear.colour.QueryExtendedVersionNumber(GearShort(0))
+        )
+        self.assertIsInstance(resp, command.NumericResponse)
+        self.assertIsNone(resp.raw_value)
+
+    def test_fake_gear_dt8_tc_limits(self):
+        addr = GearShort(4)
+
+        resp = self.bus.run_sequence(
+            QueryDT8ColourValue(
+                addr, QueryColourValueDTR.ColourTemperatureTcWarmest
+            )
+        )
+        self.assertEqual(resp, 370)
+
+        resp = self.bus.run_sequence(
+            QueryDT8ColourValue(
+                addr, QueryColourValueDTR.ColourTemperatureTcCoolest
+            )
+        )
+        self.assertEqual(resp, 153)
+
+    def test_fake_gear_dt8_tc_set(self):
+        addr = GearShort(4)
+
+        self.bus.run_sequence(SetDT8ColourValueTc(addr, 202))
+
+        resp = self.bus.run_sequence(
+            QueryDT8ColourValue(
+                addr, QueryColourValueDTR.ReportColourTemperatureTc
+            )
+        )
+        self.assertEqual(resp, 202)
 
 
 class TestFakeDevice(unittest.TestCase):
@@ -163,10 +213,18 @@ class TestFakeDevice(unittest.TestCase):
         """
         self.bus = fakes.Bus(
             [
-                fakes.Device(DeviceShort(0), memory_banks=(fakes.FakeDeviceBank0,)),
-                fakes.Device(DeviceShort(1), memory_banks=(fakes.FakeDeviceBank0,)),
-                fakes.Device(DeviceShort(2), memory_banks=(fakes.FakeDeviceBank0,)),
-                fakes.Device(DeviceShort(3), memory_banks=(fakes.FakeDeviceBank0,)),
+                fakes.Device(
+                    DeviceShort(0), memory_banks=(fakes.FakeDeviceBank0,)
+                ),
+                fakes.Device(
+                    DeviceShort(1), memory_banks=(fakes.FakeDeviceBank0,)
+                ),
+                fakes.Device(
+                    DeviceShort(2), memory_banks=(fakes.FakeDeviceBank0,)
+                ),
+                fakes.Device(
+                    DeviceShort(3), memory_banks=(fakes.FakeDeviceBank0,)
+                ),
             ]
         )
 
@@ -187,8 +245,12 @@ class TestFakeDevice(unittest.TestCase):
     def test_fake_device_status(self):
         for addr_int in range(3):
             # Make sure QueryDeviceStatus works as expected
-            resp = self.bus.send(device.general.QueryDeviceStatus(DeviceShort(addr_int)))
-            self.assertIsInstance(resp, device.general.QueryDeviceStatusResponse)
+            resp = self.bus.send(
+                device.general.QueryDeviceStatus(DeviceShort(addr_int))
+            )
+            self.assertIsInstance(
+                resp, device.general.QueryDeviceStatusResponse
+            )
             # Make sure each device has four instances which respond as expected
             for inst_num in range(4):
                 resp = self.bus.send(


### PR DESCRIPTION
Based on [a fork I'd found](https://github.com/sde1000/python-dali/compare/master...petrilgner:python-dali:master) by [Petr Ilgner](https://github.com/petrilgner/) I've added support for IEC 62386-208 DALI-2 DT8 colour temperature control gear. I've kept his original commits by cherry-picking them, so that the correct attribution remains in the commit history.

As well as the `dali.gear.colour` module, there's a new `dali.gear.sequences` module, which contains `SetDT8ColourValueTc()` and `QueryDT8ColourValue()` sequences.

I only have access to colour temperature gear, so support isn't completed for other types (e.g. RGBWAF, x-y coordinate). These should be easy enough to add in by someone who has such hardware to test with. All command opcodes have been implemented, even though I am not able to test all of them. (Note that opcodes 239, 244, 253 and 254 are "reserved" by the standard).