### PR TITLE
Fix event filter type handling for control devices

### DIFF
--- a/dali/device/general.py
+++ b/dali/device/general.py
@@ -965,7 +965,7 @@ class _Event(command.Command):
     # 'enabled_by' holds a reference to an element in an enum which, when used
     # with the appropriate 'SetEventFilter' sequence, flags if this event is
     # enabled
-    enabled_by: Optional[IntEnum] = None
+    enabled_by: Optional[InstanceEventFilter] = None
 
     _framesize = 24
     # The metaclass will call '_register_subclass()', which then adds to this

--- a/dali/device/sequences.py
+++ b/dali/device/sequences.py
@@ -115,8 +115,12 @@ def SetEventFilters(
     if isinstance(instance, int):
         instance = InstanceNumber(instance)
 
-    uses_dtr1 = filter_value.dali_width() > 8
-    uses_dtr2 = filter_value.dali_width() > 16
+    if isinstance(filter_value, InstanceEventFilter):
+        uses_dtr1 = filter_value.dali_width() > 8
+        uses_dtr2 = filter_value.dali_width() > 16
+    else:
+        uses_dtr1 = False
+        uses_dtr2 = False
 
     # The values in InstanceEventFilter are already mapped out to the
     # corresponding bits, through the inheritance from IntFlag

--- a/dali/tests/test_device_sequences.py
+++ b/dali/tests/test_device_sequences.py
@@ -233,6 +233,24 @@ def test_event_filter_pushbutton_sequence_all():
     # The previous test for the sequence adequately checks the remaining logic
 
 
+def test_event_filter_sequence_int():
+    # InstanceEventFilter ultimately inherits from int, so it should be
+    # possible to use a plain int in the sequence
+    sequence = SetEventFilters(
+        device=DeviceShort(0),
+        instance=InstanceNumber(0),
+        filter_value=3,
+    )
+    # The first message the sequence should send is DTR0
+    try:
+        cmd = sequence.send(None)
+    except StopIteration:
+        raise RuntimeError()
+    assert isinstance(cmd, DTR0)
+    assert cmd.frame.as_byte_sequence[2] == 3
+    # The previous test for the sequence adequately checks the remaining logic
+
+
 def test_event_filter_sequence_bad_type():
     sequence = SetEventFilters(
         device=DeviceShort(0),


### PR DESCRIPTION
I realised my implementation of the event filters could be slightly improved – the `InstanceEventFilter` enum is an `IntEnum`, so it makes sense for the `SetEventFilters` sequence to be able to handle using a plain `int` as well as the proper enum type. This mostly is useful for the higher-level application code I'm writing, by allowing it to be able to run `SetEventFilters` with `filter_value=0` to disable all filters regardless of type (assuming that the filters are only 8 bits wide, which is so far the case for all types I've seen).