### PR TITLE
Parse events from movement and light sensors by default

### DIFF
--- a/dali/device/__init__.py
+++ b/dali/device/__init__.py
@@ -7,3 +7,5 @@ part 103 ("General requirements - Control devices") and parts 3xx
 import dali.device.general
 import dali.device.sequences
 import dali.device.pushbutton  # noqa: F401
+import dali.device.occupancy  # noqa: F401
+import dali.device.light  # noqa: F401


### PR DESCRIPTION
Without importing these modules explicitly, the `examples/async-buswatch.py` would just report back stuff like `UnknownEvent(short_address=43, data=11)`. Rather than letting all consumers import everything, let's follow the pattern set forth by the `pushbutton.py`, and import other decoders as well.

Fixes: e79e39d Add support for DALI Occupancy Sensor devices
Fixes: f0a0755 Add support for DALI Light Sensor devices