### PR TITLE
DT8: support setting Tc limits, and other improvements

### DIFF
--- a/dali/gear/colour.py
+++ b/dali/gear/colour.py
@@ -185,6 +185,17 @@ class StoreXYCoordinatePrimaryN(_ColourCommand):
     _cmdval = 241
 
 
+class StoreColourTemperatureTcLimitDTR2(IntEnum):
+    """
+    Valid DTR2 values for the StoreColourTemperatureTcLimit command
+    """
+
+    TcCoolest = 0
+    TcWarmest = 1
+    TcPhysicalCoolest = 2
+    TcPhysicalWarmest = 3
+
+
 class StoreColourTemperatureTcLimit(_ColourCommand):
     sendtwice = True
     uses_dtr0 = True

--- a/dali/gear/colour.py
+++ b/dali/gear/colour.py
@@ -10,6 +10,21 @@ from dali import command
 from dali.gear.general import _StandardCommand
 
 
+def tc_kelvin_mirek(val: int) -> int:
+    """
+    Convert Correlated Color Temperature (CCT) between Kelvin and Mirek
+
+    When the input is in Kelvin, this function returns the value in Mirek,
+    and vice versa.
+
+    >>> tc_kelvin_mirek(6300)
+    158
+    >>> tc_kelvin_mirek(250)
+    4000
+    """
+    return int(1000000 / val)
+
+
 class QueryColourValueDTR(IntEnum):
     """
     Enum of all values from Part 209 Table 11 "Query Colour Value". See

--- a/dali/gear/colour.py
+++ b/dali/gear/colour.py
@@ -172,6 +172,7 @@ class CopyReportToTemporary(_ColourCommand):
 
 
 class StoreTYPrimaryN(_ColourCommand):
+    sendtwice = True
     uses_dtr0 = True
     uses_dtr1 = True
     uses_dtr2 = True
@@ -179,11 +180,13 @@ class StoreTYPrimaryN(_ColourCommand):
 
 
 class StoreXYCoordinatePrimaryN(_ColourCommand):
+    sendtwice = True
     uses_dtr2 = True
     _cmdval = 241
 
 
 class StoreColourTemperatureTcLimit(_ColourCommand):
+    sendtwice = True
     uses_dtr0 = True
     uses_dtr1 = True
     uses_dtr2 = True
@@ -191,11 +194,13 @@ class StoreColourTemperatureTcLimit(_ColourCommand):
 
 
 class StoreGearFeaturesStatus(_ColourCommand):
+    sendtwice = True
     uses_dtr0 = True
     _cmdval = 243
 
 
 class AssignColourToLinkedChannel(_ColourCommand):
+    sendtwice = True
     uses_dtr0 = True
     _cmdval = 245
 

--- a/dali/gear/general.py
+++ b/dali/gear/general.py
@@ -680,6 +680,7 @@ class QueryDeviceTypeResponse(command.Response):
               4: "incandescent lamp dimmer",
               5: "dc-controlled dimmer",
               6: "LED lamp",
+              7: "Switching function",
               8: "Colour control",
               254: "none / end",
               255: "multiple"}
@@ -701,6 +702,7 @@ class QueryDeviceType(_StandardCommand):
     4: incandescent lamps
     5: DC-controlled dimmers
     6: LED lamps
+    7: Switching function
     8: Colour control
 
     The device type affects which application extended commands the

--- a/dali/gear/general.py
+++ b/dali/gear/general.py
@@ -680,6 +680,7 @@ class QueryDeviceTypeResponse(command.Response):
               4: "incandescent lamp dimmer",
               5: "dc-controlled dimmer",
               6: "LED lamp",
+              8: "Colour control",
               254: "none / end",
               255: "multiple"}
 
@@ -700,6 +701,7 @@ class QueryDeviceType(_StandardCommand):
     4: incandescent lamps
     5: DC-controlled dimmers
     6: LED lamps
+    8: Colour control
 
     The device type affects which application extended commands the
     device will respond to.

--- a/dali/gear/sequences.py
+++ b/dali/gear/sequences.py
@@ -12,8 +12,9 @@ from dali.gear.colour import (
     QueryColourValue,
     QueryColourValueDTR,
     SetTemporaryColourTemperature,
+    StoreColourTemperatureTcLimit,
 )
-from dali.gear.general import DTR0, DTR1, QueryActualLevel, QueryContentDTR0
+from dali.gear.general import DTR0, DTR1, DTR2, QueryActualLevel, QueryContentDTR0
 
 
 def SetDT8ColourValueTc(
@@ -84,3 +85,29 @@ def QueryDT8ColourValue(
             col_val = None
 
     return col_val
+
+
+def SetDT8TcLimit(
+    address: GearAddress,
+    what_limit: int,
+    tc_mired: int,
+) -> Generator[command.Command, Optional[command.Response], None]:
+    """
+    A generator sequence to set the Colour Temperature limit of a DT8 control
+    gear. Note that this sequence assumes that the address being targeted
+    supports DT8 Tc control, it will not check this before sending commands.
+
+    :param address: GearAddress (i.e. short, group, broadcast) address to set
+    :param what_limit: What limit to set, from dali.gear.colour.StoreColourTemperatureTcLimitDTR2
+    :param tc_mired: An int of the colour temperature to set, in mired
+    """
+    # Although the proper types are expected, ints are common enough for
+    # addresses and their meaning is unambiguous in this context
+    if isinstance(address, int):
+        address = GearShort(address)
+
+    tc_bytes = tc_mired.to_bytes(length=2, byteorder="little")
+    yield DTR0(tc_bytes[0])
+    yield DTR1(tc_bytes[1])
+    yield DTR2(what_limit)
+    yield StoreColourTemperatureTcLimit(address)

--- a/dali/gear/sequences.py
+++ b/dali/gear/sequences.py
@@ -21,7 +21,7 @@ def SetDT8ColourValueTc(
     tc_mired: int,
 ) -> Generator[command.Command, Optional[command.Response], None]:
     """
-    A generator sequence set query the Colour Temperature of a DT8 control
+    A generator sequence to set the Colour Temperature of a DT8 control
     gear. Note that this sequence assumes that the address being targeted
     supports DT8 Tc control, it will not check this before sending commands.
 

--- a/examples/async-tc.py
+++ b/examples/async-tc.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import asyncio
+import logging
+import sys
+
+from dali.address import GearGroup, GearShort
+from dali.gear.colour import tc_kelvin_mirek, QueryColourValueDTR, QueryColourStatus, StoreColourTemperatureTcLimitDTR2
+from dali.gear.general import QueryControlGearPresent, QueryActualLevel
+from dali.gear.led import QueryDimmingCurve
+from dali.gear.sequences import SetDT8ColourValueTc, SetDT8TcLimit, QueryDT8ColourValue
+from dali.driver.hid import tridonic
+from dali.sequences import QueryDeviceTypes, DALISequenceError
+
+def print_command_and_response(dev, command, response, config_command_error):
+    # Note that these will be printed "late" because they are not
+    # delivered until main() blocks on its next await call
+    if config_command_error:
+        print(f"ERROR: failed config command: {command}")
+    elif command and not response:
+        print(f"{command}")
+    else:
+        print(f"{command} -> {response}")
+
+def show_usage():
+    print(f'Usage: {sys.argv[0]} "show-all-gear" ["detailed"]')
+    print(f'       {sys.argv[0]} ("address" / "group") <number> ("tc" / "physical-cool" / "physical-warm" / "cool" / "warm") <Tc>')
+    sys.exit(1)
+
+async def scan_control_gear(d, detailed):
+    for addr in (GearShort(x) for x in range(64)):
+        try:
+            device_types = await d.run_sequence(QueryDeviceTypes(addr))
+        except DALISequenceError:
+            continue
+
+        if 6 in device_types:
+            curve = await d.send(QueryDimmingCurve(addr))
+            arc_raw = await d.send(QueryActualLevel(addr))
+            if curve.raw_value.as_integer == 0:
+                if arc_raw.value >= 1:
+                    arc_power = 10 ** (((arc_raw.value-1)/(253/3))-1)
+                else:
+                    arc_power = 0
+            elif curve.raw_value.as_integer == 1:
+                arc_power = arc_raw.value / 254
+            else:
+                arc_power = None
+
+        if 8 in device_types:
+            colour_status = await d.send(QueryColourStatus(addr))
+            if colour_status.colour_type_colour_temperature_Tc_active:
+                tc = await d.run_sequence(QueryDT8ColourValue(address=addr, query=QueryColourValueDTR.ColourTemperatureTC))
+                if detailed:
+                    tc_coolest = await d.run_sequence(QueryDT8ColourValue(address=addr, query=QueryColourValueDTR.ColourTemperatureTcCoolest))
+                    tc_physical_coolest = await d.run_sequence(QueryDT8ColourValue(address=addr, query=QueryColourValueDTR.ColourTemperatureTcPhysicalCoolest))
+                    tc_warmest = await d.run_sequence(QueryDT8ColourValue(address=addr, query=QueryColourValueDTR.ColourTemperatureTcWarmest))
+                    tc_physical_warmest = await d.run_sequence(QueryDT8ColourValue(address=addr, query=QueryColourValueDTR.ColourTemperatureTcPhysicalWarmest))
+                    tc_detailed_info = f" ({tc_kelvin_mirek(tc_warmest)}-{tc_kelvin_mirek(tc_coolest)}K, physical {tc_kelvin_mirek(tc_physical_warmest)}-{tc_kelvin_mirek(tc_physical_coolest)}K)"
+                else:
+                    tc_detailed_info = ""
+                print(f"{addr}: {arc_power:.01f}%, Tc {tc_kelvin_mirek(tc)}K{tc_detailed_info}")
+
+async def main():
+    d = tridonic("/dev/dali/daliusb-*", glob=True)
+
+    if len(sys.argv) < 2:
+        show_usage()
+
+    if sys.argv[1] == 'show-all-gear':
+        mode = 'show-all-gear'
+        if len(sys.argv) >= 3 and sys.argv[2] == 'detailed':
+            detailed = True
+        else:
+            detailed = False
+    else:
+        mode = None
+        if len(sys.argv) < 4:
+            show_usage()
+
+        if sys.argv[1] == 'address':
+            address = GearShort(int(sys.argv[2]))
+        elif sys.argv[1] == 'group':
+            address = GearGroup(int(sys.argv[2]))
+        else:
+            show_usage()
+
+        if sys.argv[3] == 'physical-cool':
+            setting_a_limit = StoreColourTemperatureTcLimitDTR2.TcPhysicalCoolest
+        elif sys.argv[3] == 'physical-warm':
+            setting_a_limit = StoreColourTemperatureTcLimitDTR2.TcPhysicalWarmest
+        elif sys.argv[3] == 'cool':
+            setting_a_limit = StoreColourTemperatureTcLimitDTR2.TcCoolest
+        elif sys.argv[3] == 'warm':
+            setting_a_limit = StoreColourTemperatureTcLimitDTR2.TcWarmest
+        elif sys.argv[3] == 'tc':
+            setting_a_limit = None
+        else:
+            show_usage()
+        desired_kelvin = int(sys.argv[4])
+        tc_mired = tc_kelvin_mirek(desired_kelvin)
+
+    # Uncomment to show a dump of bus traffic
+    # d.bus_traffic.register(print_command_and_response)
+
+    # If there's a problem sending a command, keep trying
+    d.exceptions_on_send = False
+
+    d.connect()
+    await d.connected.wait()
+
+    if mode == 'show-all-gear':
+        await scan_control_gear(d, detailed)
+    else:
+        if setting_a_limit is not None:
+            command = SetDT8TcLimit(address=address, what_limit=setting_a_limit, tc_mired=tc_mired)
+        else:
+            command = SetDT8ColourValueTc(address=address, tc_mired=tc_mired)
+        await d.run_sequence(command)
+
+    # If we don't sleep here for a moment, the bus_watch task gets
+    # killed before it delivers our most recent command.
+    await asyncio.sleep(0.1)
+    d.disconnect()
+
+if __name__ == "__main__":
+    # logging.basicConfig(level=logging.DEBUG)
+    asyncio.run(main())


### PR DESCRIPTION
I have a bunch of DT8 Osram OTi DALI DT6/8 devices which are by default set to something like 2700-6400K, but my LED strips have a different CT. Lunatone's SW won't allow me to change the *physical* Tc limits, so let's write a script which assists with this configuration.

Also some unrelated bugfixes as standalone commits.

### led: DT8: recognize Colour Control device type when parsing a BackwardFrame

Without this patch, dumping DALI traffic would show stuff like this:
```
QueryDeviceType(<address (control gear) 0>) -> multiple
QueryNextDeviceType(<address (control gear) 0>) -> LED lamp
QueryNextDeviceType(<address (control gear) 0>) -> BackwardFrame(8)
QueryNextDeviceType(<address (control gear) 0>) -> none / end
```
### recognize DT7 switching relays when querying device types

### led: DT8: configuration commands need sending twice

This is as per 62386-209:2011, section 11.3.4.2, "Application extended configuration commands".

### led: DT8: fix a copy/paste error in `SetDT8ColourValueTc`

Fixes: b706666 Expand DT8 support with tests and sequences

### led: DT8: a sequence for setting Tc limits

### led: DT8: a helper for conversion between K and Mirek for Tc

The standard talks about "Mirek", which is the SI lingo for Mired. I think that everybody else uses Kelvin, so let's add a helper function.

### examples: getting and setting a Tc for DT8 CCT LEDs