### PR TITLE
tridonic: Fix bus traffic dumping

### DIFF
--- a/dali/driver/hid.py
+++ b/dali/driver/hid.py
@@ -520,7 +520,7 @@ class tridonic(hid):
                     frame = dali.frame.BackwardFrame(raw_frame)
                 elif rtype == self._RESPONSE_NO_FRAME:
                     frame = "no"
-                elif rtype == self._RESPONSE_BUS_STATUS \
+                elif rtype == self._RESPONSE_INFO \
                      and message[5] == self._BUS_STATUS_FRAMING_ERROR:
                     frame = dali.frame.BackwardFrameError(255)
                 else:


### PR DESCRIPTION
I have more than one control device, which is why the `examples/async-dalitest.py` hits a framing error when checking if there are any control devices connected. When the bus_watch feature is enabled, this hit a Python error due to some incomplete rename/refactoring where this single occurrence was not changed by mistake.

Fixes: c72374c ("Update the async Tridonic DALI-USB driver to work with 24-bit frames")