### PR TITLE
hid: fix wrong variable name

### DIFF
--- a/dali/driver/hid.py
+++ b/dali/driver/hid.py
@@ -549,7 +549,7 @@ class tridonic(hid):
                             current_command = None
                             continue
                         else:
-                            self._log.debug("Failed config command (second frame didn't match): %s", current_comment)
+                            self._log.debug("Failed config command (second frame didn't match): %s", current_command)
                             self.bus_traffic._invoke(current_command, None, True)
                             current_command = None
                             # Fall through to continue processing frame


### PR DESCRIPTION
That's the endless joy of languages with no compile-time variable lookup.

Fixes: ea01ab3 ("asyncio-based drivers for USB devices that present as HID")