### PR TITLE
tridonic: support sending 8-bit backward frames

### DIFF
--- a/dali/driver/hid.py
+++ b/dali/driver/hid.py
@@ -404,6 +404,15 @@ class tridonic(hid):
                 self.disconnect(reconnect=True)
                 raise CommunicationError
 
+    @staticmethod
+    def _command_mode(frame):
+        if len(frame) == 8:
+            return tridonic._SEND_MODE_DALI8
+        if len(frame) == 16:
+            return tridonic._SEND_MODE_DALI16
+        if len(frame) == 24:
+            return tridonic._SEND_MODE_DALI24
+        raise UnsupportedFrameTypeError
 
     async def _send_raw(self, command):
         frame = command.frame
@@ -423,8 +432,7 @@ class tridonic(hid):
             data = self._cmd(
                 self._CMD_SEND, seq,
                 ctrl=self._SEND_CTRL_SENDTWICE if command.sendtwice else 0,
-                mode=self._SEND_MODE_DALI16 if len(frame) == 16
-                else self._SEND_MODE_DALI24,
+                mode=self._command_mode(frame),
                 frame=frame.pack_len(4))
             try:
                 os.write(self._f, data)


### PR DESCRIPTION
~~I have no idea if this actually reaches the physical DALI bus, but~~ I've checked that the bus watcher picks up the traffic. So, this can be already used to persuade some real code that's connected to the real DALI bus that a sensor "sent us something".

I have some internal code that switches my DALI lights on and off based on a DALI movement sensor. With this patch in place, I can simulate this movement, and my light went on, as if someone really walked in our hallway:

```python
from dali.device.occupancy import OccupancyEvent
x = OccupancyEvent(short_address=45, instance_number=0,
  data=OccupancyEvent.EventData(movement=True, occupied=True))
await dev.send(x)
```

Caveat: the usual bits about addressing of event messages apply (I tried to write this up at [electronics stackexchange](https://electronics.stackexchange.com/questions/660840/dali-control-device-addressing-modes-and-event-source-schemes)). In this library it's done via `DeviceInstanceTypeMapper`, so in this example code it was important to ensure that there's really a physical control device on the bus at address A² = `45` which really has an instance no. = `0` which reports that it implements part 303, occupancy sensor. The other way would be faking that, of course. The root cause is that these 8-bit frames are too short to encode all the event info, and something has to perform this discovery up front, or has the knowledge of "hey, A² X, instance Y is a movement sensor" that's provided out-of-band.

Bug: https://github.com/sde1000/python-dali/discussions/126