### PR TITLE
Control Devices: respect "resolution" when reading "inputValue"

### DIFF
--- a/examples/async-dalitest.py
+++ b/examples/async-dalitest.py
@@ -6,6 +6,7 @@ from dali.address import GearShort, GearBroadcast, \
     DeviceShort, DeviceBroadcast, InstanceNumber
 import dali.gear.general as gg
 import dali.device.general as dg
+import dali.device.sequences as ds
 from dali.gear import emergency
 from dali.gear import led
 from dali.sequences import QueryDeviceTypes, DALISequenceError
@@ -85,9 +86,9 @@ async def scan_control_devices(d):
         for instance in (InstanceNumber(x) for x in range(instances.value)):
             print(f" -{instance}- enabled: {await d.send(dg.QueryInstanceEnabled(addr, instance))}")
             print(f" -{instance}- type: {await d.send(dg.QueryInstanceType(addr, instance))}")
-            print(f" -{instance}- resolution: {await d.send(dg.QueryResolution(addr, instance))}")
-            print(f" -{instance}- value: {await d.send(dg.QueryInputValue(addr, instance))}")
-            # XXX read remaining bytes of value
+            resolution = await d.send(dg.QueryResolution(addr, instance))
+            print(f" -{instance}- resolution: {resolution}")
+            print(f" -{instance}- value: {await d.run_sequence(ds.query_input_value(addr, instance, resolution.value))}")
             print(f" -{instance}- feature type: {await d.send(dg.QueryFeatureType(addr, instance))}")
         #for b in (info.BANK_0, oem.BANK_1):
         #    try:


### PR DESCRIPTION
The standard (62386-103:2014, chapter 9.7) states that the "resolution" of an instance is not always 8-bits. If it's any longer, a proper read involves a transaction and a sequence of commands. If the number is not divisible by 8, extra trailing bits have to be truncated.

Tested on Lunatone DALI-2 MC (`86459532-2`) and Lunatone CS-2 (`86458670`). The push button coupler is a part-301 device where the standard says that the on-the-wire values are either `0x00` or `0xff`, but the actual resolution (and therefore the correct numeric value) is either 0 or 1. The other device, a combined movement sensor with a light meter, supports 11 bits of resolution for the lux meter and therefore it requires a `"QUERY INPUT VALUE"` followed by a `"QUERY INPUT VALUE LATCH"` and dropping the extra 5 bits.