### PR TITLE
DeviceInstanceMapper: do not skip devices with inputDeviceError

### DIFF
--- a/dali/device/helpers.py
+++ b/dali/device/helpers.py
@@ -127,8 +127,7 @@ class DeviceInstanceTypeMapper:
             if isinstance(rsp, QueryDeviceStatusResponse):
                 # Make sure the status is OK
                 if (
-                    rsp.input_device_error
-                    or rsp.short_address_is_mask
+                    rsp.short_address_is_mask
                     or rsp.reset_state
                 ):
                     continue

--- a/dali/tests/test_device_sequences.py
+++ b/dali/tests/test_device_sequences.py
@@ -73,7 +73,7 @@ class DeviceFakeError(fakes.Device):
     _device_status = 0b00000001
 
 
-def test_device_autodiscover_skip_bad(fakes_bus):
+def test_device_autodiscover_dont_skip_bad(fakes_bus):
     dev_inst_map = DeviceInstanceTypeMapper()
     # Add an extra fake device, one with an error bit set
     fakes_bus.gear.append(
@@ -86,8 +86,8 @@ def test_device_autodiscover_skip_bad(fakes_bus):
     assert rsp.input_device_error
 
     fakes_bus.run_sequence(dev_inst_map.autodiscover())
-    # The device in error mode shouldn't have had its instances counted
-    assert len(dev_inst_map.mapping) == 12
+    # The mere fact that a device has "inputDeviceError" set does not mean it is not usable
+    assert len(dev_inst_map.mapping) == 16
 
 
 class DeviceNoInstances(fakes.Device):


### PR DESCRIPTION
I have a bunch of non-pushbutton switches connected to some of my Lunatone DALI-2 MC pushbutton couplers. These devices unfortunately set the `"inputDeviceError"` bit whenever any of its inputs is closed/shorted for longer than `T_stuck`.

The 62386-301:2017 says (Table 4, page 15) that this timer is up to 255s, which is definitely not enough for a door sensor. The same standard then says that such errors should be propagated to bit 0 in the `"instanceErrorByte"`, which python-dali does not query. However, my devices unfortunately also propagate this status into the `"inputDeviceError"`, and that means that the initial discovery of instance numbers to instance types won't recognize these buttons at all.

I was not able to find a reference in the standard whether any `"instanceError"` propagates to the `"inputDeviceError"`, but even if this was an incorrect behavior, these devices exist, one can buy them, and presumably using them as a kind-of persistent contact inputs still makes sense; just to provide some data, I have:

- magnet and a reed switch for door status monitoring,
- a "permanent" switch for disabling automation at a hallway where our baby sometimes sleeps.

I think that both use cases make sense, and I would prefer python-dali to not skip over some input devices which actually work just fine.

Fixes: 0cfddb7