### PR TITLE
DT8: clarify why "QUERY ACTUAL LEVEL" is needed

### DIFF
--- a/dali/gear/sequences.py
+++ b/dali/gear/sequences.py
@@ -69,6 +69,7 @@ def QueryDT8ColourValue(
             "'query' must be a value from QueryColourValueDTR enumerator"
         )
 
+    # 62386-209, command 250, Note 2: start by sending "QUERY ACTUAL LEVEL"
     yield QueryActualLevel(address)
     yield DTR0(query.value)
     msb = yield QueryColourValue(address)


### PR DESCRIPTION
I was wondering why the code was sending a seemingly useless command, but it turns out that this is explicitly mandated by a note in the standard. Let's put that into a comment.