### PR TITLE
Update Debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: python
 X-Python3-Version: >= 3.7
 Priority: optional
 Maintainer: Stephen Early <steve@assorted.org.uk>
-Build-Depends: debhelper-compat (= 12), dh-python, python3-all, python3-setuptools
+Build-Depends: debhelper-compat (= 12), dh-python, python3-all, python3-setuptools, python3-serial-asyncio
 Standards-Version: 3.9.6
 
 Package: python3-dali


### PR DESCRIPTION
Fix error during debian package build:
```sh
ModuleNotFoundError: No module named 'serial_asyncio'
```